### PR TITLE
Added OBO metadata

### DIFF
--- a/src/ontology/bto-edit.obo
+++ b/src/ontology/bto-edit.obo
@@ -6,6 +6,9 @@ synonymtypedef: FR "LANGUAGE FRENCH"
 synonymtypedef: GE "LANGUAGE GERMAN"
 synonymtypedef: MS "MISSPELLING"
 synonymtypedef: SCI "SCIENTIFIC NAME"
+property_value: http://purl.org/dc/elements/1.1/description "A structured controlled vocabulary for the source of an enzyme comprising tissues, cell lines, cell types and cell cultures." xsd:string
+property_value: http://purl.org/dc/elements/1.1/title "The BRENDA Tissue Ontology (BTO)" xsd:string
+property_value: http://purl.org/dc/terms/license https://creativecommons.org/licenses/by/4.0/ xsd:string
 default-namespace: file:Z:/Daten/Marion_Arbeit/3_TU_BS_enzymeta/tissue ontology DAG Editor/BrendaTissueOBO1367
 
 [Term]


### PR DESCRIPTION
This adds the required OBO metadata to BTO: Title, Description and License.