### PR TITLE
Standardize contributions

### DIFF
--- a/src/ontology/bto-edit.obo
+++ b/src/ontology/bto-edit.obo
@@ -15,7 +15,8 @@ property_value: http://purl.org/dc/terms/license https://creativecommons.org/lic
 [Term]
 id: BTO:0000000
 name: tissues, cell types and enzyme sources
-def: "A structured controlled vocabulary for the source of an enzyme. It comprises terms of tissues, cell lines, cell types and cell cultures from uni- and multicellular organisms." [curators:mgr]
+def: "A structured controlled vocabulary for the source of an enzyme. It comprises terms of tissues, cell lines, cell types and cell cultures from uni- and multicellular organisms." []
+created_by: Marion Gremse
 
 [Term]
 id: BTO:0000001
@@ -216,7 +217,8 @@ relationship: part_of BTO:0001376 ! thigh
 [Term]
 id: BTO:0000031
 name: fruit peduncle
-def: "A short stalk at the base of a fruit." [curators:mgr]
+def: "A short stalk at the base of a fruit." []
+created_by: Marion Gremse
 relationship: part_of BTO:0000486 ! fruit
 
 [Term]
@@ -531,7 +533,7 @@ id: BTO:0000070
 name: fungal cell line
 synonym: "fungus cell line" RELATED []
 relationship: develops_from BTO:0001494 ! fungus
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-16T10:31:59Z
 
 [Term]
@@ -778,7 +780,7 @@ name: Colon 26-L5 cell
 def: "Murine cancer cell line." [PMID:19952433]
 synonym: "26-L5 cell" RELATED []
 relationship: develops_from BTO:0004013 ! Colon-26 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-01-28T05:43:17Z
 
 [Term]
@@ -1289,7 +1291,7 @@ def: "The H226Br cell line is a variant of the NCI-H226 cell line derived from a
 synonym: "H-226Br cell" RELATED []
 synonym: "H226Br cell" RELATED []
 relationship: develops_from BTO:0003008 ! NCI-H226 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-03T20:51:18Z
 
 [Term]
@@ -3683,7 +3685,7 @@ id: BTO:0000512
 name: primary oocyte
 def: "The immature reproductive cell prior to fertilization; it is derived from an oogonium, and is called a primary oocyte prior to completion of the first maturation division, and a secondary oocyte between the first and second maturation division." [Dorlands_Medical_Dictionary:MerckSource]
 is_a: BTO:0000964 ! oocyte
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-07-22T09:29:24Z
 
 [Term]
@@ -3776,7 +3778,7 @@ name: A-875 cell
 def: "Human melanoma cell line." [PMID:8270000]
 synonym: "A875 cell" RELATED []
 is_a: BTO:0000849 ! melanoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-01-28T05:49:39Z
 
 [Term]
@@ -4922,9 +4924,10 @@ is_a: BTO:0000741 ! lymphocytic leukemia cell line
 [Term]
 id: BTO:0000682
 name: Koji culture
-def: "Solid-state culture of fungus (e.g. aspergillus, penicilium) on wheat bran or other cereals." [curators:mgr]
+def: "Solid-state culture of fungus (e.g. aspergillus, penicilium) on wheat bran or other cereals." []
 is_a: BTO:0000214 ! cell culture
 is_a: BTO:0001494 ! fungus
+created_by: Marion Gremse
 
 [Term]
 id: BTO:0000683
@@ -6073,8 +6076,9 @@ is_a: BTO:0000264 ! bone marrow cell line
 [Term]
 id: BTO:0000845
 name: meiotic cell
-def: "A cell that undergoes meiosis: the cellular process that results in the number of chromosomes in gamete-producing cells being reduced to one half and that involves a reduction division in which one of each pair of homologous chromosomes passes to each daughter cell and a mitotic division." [curators:mgr, From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.m-w.com/cgi-bin/dictionary?book=Dictionary&va=meiosis]
+def: "A cell that undergoes meiosis: the cellular process that results in the number of chromosomes in gamete-producing cells being reduced to one half and that involves a reduction division in which one of each pair of homologous chromosomes passes to each daughter cell and a mitotic division." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.m-w.com/cgi-bin/dictionary?book=Dictionary&va=meiosis]
 synonym: "meiocyte" RELATED []
+created_by: Marion Gremse
 is_a: BTO:0001434 ! vegetative cell
 
 [Term]
@@ -6425,7 +6429,7 @@ relationship: part_of BTO:0000022 ! abdominal ganglion
 id: BTO:0000897
 name: amnion epithelium
 relationship: part_of BTO:0000065 ! amnion
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-01-28T05:56:24Z
 
 [Term]
@@ -6466,7 +6470,7 @@ synonym: "plant tracheid" RELATED []
 synonym: "trachea" RELATED []
 synonym: "tracheid" RELATED []
 relationship: part_of BTO:0001429 ! vascular bundle
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2013-11-07T09:22:23Z
 
 [Term]
@@ -6579,7 +6583,7 @@ name: 8305C cell
 def: "Human thyroid carcinoma cell line, established from the primary tumor of a 67-year-old woman with primary thyroid undifferentiated carcinoma." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 synonym: "8305-C cell" RELATED []
 is_a: BTO:0003209 ! anaplastic thyroid cancer cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-28T03:53:43Z
 
 [Term]
@@ -6731,8 +6735,9 @@ relationship: part_of BTO:0004680 ! stratum basale
 [Term]
 id: BTO:0000940
 name: juice vesicle
-def: "The membranous and fluid-filled cell in a plant." [curators:mgr]
+def: "The membranous and fluid-filled cell in a plant." []
 relationship: part_of BTO:0000486 ! fruit
+created_by: Marion Gremse
 
 [Term]
 id: BTO:0000941
@@ -7203,7 +7208,7 @@ name: amnion epithelial cell
 def: "A form of stem cells extracted from the lining of the inner membrane of the placenta." [Wikipedia:The_Free_Encyclopedia]
 synonym: "amniotic epithelial cell" RELATED []
 relationship: part_of BTO:0000897 ! amnion epithelium
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-01-28T05:56:47Z
 
 [Term]
@@ -7258,10 +7263,11 @@ relationship: part_of BTO:0001448 ! visceral hump
 [Term]
 id: BTO:0001013
 name: pedal muscle
-def: "The foot retractor or protractor muscle of a shell." [curators:mgr]
+def: "The foot retractor or protractor muscle of a shell." []
 is_a: BTO:0000887 ! muscle
 is_a: BTO:0001262 ! soft body part
 relationship: part_of BTO:0001266 ! invertebrate muscular system
+created_by: Marion Gremse
 
 [Term]
 id: BTO:0001014
@@ -7565,7 +7571,7 @@ id: BTO:0001055
 name: ovarian epithelial cell
 synonym: "OEC cell" RELATED []
 relationship: part_of BTO:0003661 ! ovary epithelium
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-08-04T08:55:54Z
 
 [Term]
@@ -9832,7 +9838,7 @@ name: amnion epithelial cell line
 synonym: "amniotic epithelial cell line" RELATED []
 is_a: BTO:0000110 ! amniotic cell line
 relationship: develops_from BTO:0001005 ! amnion epithelial cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-01-28T05:58:03Z
 
 [Term]
@@ -10529,7 +10535,7 @@ is_a: BTO:0001171 ! spore
 [Term]
 id: BTO:0001476
 name: mitotic cell
-def: "A cell that undergoes mitosis: a process that takes place in the nucleus of a dividing cell, involves typically a series of steps consisting of prophase, metaphase, anaphase, and telophase, and results in the formation of two new nuclei each having the same number of chromosomes as the parent nucleus." [curators:mgr, From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.m-w.com/cgi-bin/dictionary?book=Dictionary&va=mitosis]
+def: "A cell that undergoes mitosis: a process that takes place in the nucleus of a dividing cell, involves typically a series of steps consisting of prophase, metaphase, anaphase, and telophase, and results in the formation of two new nuclei each having the same number of chromosomes as the parent nucleus." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.m-w.com/cgi-bin/dictionary?book=Dictionary&va=mitosis]
 is_a: BTO:0001434 ! vegetative cell
 
 [Term]
@@ -10637,8 +10643,9 @@ is_a: BTO:0000042 ! animal
 [Term]
 id: BTO:0001490
 name: other source
-def: "Other sources of an enzyme as cell culture or commercial preparation, not related to a specific tissue." [curators:mgr]
+def: "Other sources of an enzyme as cell culture or commercial preparation, not related to a specific tissue." []
 is_a: BTO:0000000 ! tissues, cell types and enzyme sources
+created_by: Marion Gremse
 
 [Term]
 id: BTO:0001491
@@ -10959,7 +10966,7 @@ id: BTO:0001539
 name: parenchyma
 def: "The tissue characteristic of an organ, as distinguished from associated connective or supporting tissues." [The_American_Heritage_Dictionary_of_the_English_Language:Fourth_Edition_copyright_2000]
 relationship: part_of BTO:0001491 ! viscus
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2013-11-07T09:33:34Z
 
 [Term]
@@ -11083,7 +11090,7 @@ id: BTO:0001554
 name: 661W cell
 def: "Retinal cell culture of murine 661W photoreceptor-derived cells." [PMID:12407171]
 is_a: BTO:0003061 ! retinal cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-01-28T06:02:14Z
 
 [Term]
@@ -11094,7 +11101,7 @@ synonym: "uterine endometrial cancer cell line" RELATED []
 synonym: "uterine endometrial carcinoma cell line" RELATED []
 is_a: BTO:0001996 ! endometrial cell line
 relationship: develops_from BTO:0000257 ! uterine cancer cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-01-28T06:07:46Z
 
 [Term]
@@ -12605,7 +12612,7 @@ id: BTO:0001771
 name: AN3CA cell
 def: "Endometrial carcinoma cell line." [PMID:15256444]
 is_a: BTO:0001555 ! endometrial cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-01-28T06:08:39Z
 
 [Term]
@@ -13187,8 +13194,9 @@ is_a: BTO:0001853 ! vascular endothelium
 [Term]
 id: BTO:0001853
 name: vascular endothelium
-def: "The innermost lining of a blood vessel." [curators:mgr]
+def: "The innermost lining of a blood vessel." []
 is_a: BTO:0000393 ! endothelium
+created_by: Marion Gremse
 
 [Term]
 id: BTO:0001854
@@ -13295,7 +13303,7 @@ id: BTO:0001866
 name: bronchiolar epithelium
 is_a: BTO:0000419 ! respiratory epithelium
 relationship: part_of BTO:0002375 ! bronchiole
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-01-28T06:15:09Z
 
 [Term]
@@ -13559,7 +13567,8 @@ is_a: BTO:0003883 ! pancreatic ductal adenocarcinoma cell line
 [Term]
 id: BTO:0001905
 name: tail muscle
-def: "A muscle of the tail." [curators:mgr]
+def: "A muscle of the tail." []
+created_by: Marion Gremse
 is_a: BTO:0000887 ! muscle
 is_a: BTO:0001103 ! skeletal muscle
 relationship: part_of BTO:0001266 ! invertebrate muscular system
@@ -13578,7 +13587,6 @@ name: P3/NS1/1-Ag4.1 cell
 def: "Mouse myeloma cell line." [PMID:12665628]
 synonym: " NS-1-Ag4-1 cell" RELATED []
 synonym: "3 NS1 Ag4/1 cell" RELATED []
-synonym: "<new synonym>" RELATED []
 synonym: "GM-3573 cell" RELATED []
 synonym: "GM03573 cell" RELATED []
 synonym: "GM03573A cell" RELATED []
@@ -13997,7 +14005,7 @@ def: "A dead body." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Web
 synonym: "cadaver" RELATED []
 synonym: "dead body" RELATED []
 relationship: develops_from BTO:0000284 ! organism form
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-01-28T06:19:19Z
 
 [Term]
@@ -14349,7 +14357,7 @@ id: BTO:0002017
 name: plant reproductive system
 def: "Any of the systems, sexual or asexual, by which plants reproduce." [Encyclopaedia_Britannica:http\://www.britannica.com/]
 relationship: part_of BTO:0001461 ! whole plant
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-07-22T09:43:15Z
 
 [Term]
@@ -14551,8 +14559,9 @@ relationship: develops_from BTO:0001345 ! T-24 cell
 [Term]
 id: BTO:0002044
 name: frond tip
-def: "The outer end of the frond." [curators:mgr]
+def: "The outer end of the frond." []
 relationship: part_of BTO:0000483 ! frond
+created_by: Marion Gremse
 
 [Term]
 id: BTO:0002045
@@ -14567,7 +14576,7 @@ def: "A male reproductive cell produced in an antheridium, as in algae, fungi, a
 synonym: "antherozoid" RELATED []
 synonym: "plant sperm" RELATED []
 relationship: part_of BTO:0003374 ! antheridium
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-01-28T08:29:27Z
 
 [Term]
@@ -14999,8 +15008,9 @@ is_a: BTO:0000456 ! plasmacytoma cell line
 [Term]
 id: BTO:0002103
 name: MOPC-173 cell
-def: "Murine plasmacytoma cell line; also described as mouse myeloma tumor." [curators:mgr, PMID:7297559]
+def: "Murine plasmacytoma cell line; also described as mouse myeloma tumor." [PMID:7297559]
 synonym: "MOPC 173 cell" RELATED []
+created_by: Marion Gremse
 is_a: BTO:0000456 ! plasmacytoma cell line
 
 [Term]
@@ -15305,7 +15315,7 @@ id: BTO:0002146
 name: CAL-62 cell
 def: "Human thyroid anaplastic carcinoma cell line, established from the thyroid gland (right lobe) of a 70-year-old woman with thyroid anaplastic carcinoma in 1988; described as being tumorigenic in heterotransplanted nude mice." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 is_a: BTO:0003209 ! anaplastic thyroid cancer cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-28T04:03:16Z
 
 [Term]
@@ -15935,7 +15945,7 @@ id: BTO:0002242
 name: oral epithelial cell
 synonym: "OEC cell" RELATED []
 relationship: part_of BTO:0001775 ! oral epithelium
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-08-04T09:02:16Z
 
 [Term]
@@ -15992,7 +16002,7 @@ synonym: "cavity of cervix" RELATED []
 synonym: "cervical canal of uterus" RELATED []
 synonym: "endocervical canal" RELATED []
 relationship: part_of BTO:0001421 ! uterine cervix
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-17T10:11:30Z
 
 [Term]
@@ -16111,9 +16121,10 @@ is_a: BTO:0002322 ! cell property
 [Term]
 id: BTO:0002265
 name: microplasmodium
-def: "The aggregation stage of Physarum polycephalum." [curators:mgr]
+def: "The aggregation stage of Physarum polycephalum." []
 is_a: BTO:0000757 ! plasmodium
 is_a: BTO:0002007 ! aggregation stage
+created_by: Marion Gremse
 
 [Term]
 id: BTO:0002266
@@ -16174,7 +16185,7 @@ name: BHT-101 cell
 def: "Human thyroid carcinoma cell line; established from the lymph node metastasis of a 63-year-old woman with anaplastic papillary thyroid carcinoma." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 is_a: BTO:0003209 ! anaplastic thyroid cancer cell line
 is_a: BTO:0003210 ! papillary thyroid cancer cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-28T04:05:36Z
 
 [Term]
@@ -16211,8 +16222,9 @@ is_a: BTO:0002278 ! macrophage cell line
 [Term]
 id: BTO:0002280
 name: lignifying cell
-def: "A lignifying cell deposits lignin in its cell wall. Lignifying cells are localized in different plant tissues." [curators:mgr]
+def: "A lignifying cell deposits lignin in its cell wall. Lignifying cells are localized in different plant tissues." []
 relationship: part_of BTO:0001461 ! whole plant
+created_by: Marion Gremse
 
 [Term]
 id: BTO:0002281
@@ -16308,8 +16320,9 @@ is_a: BTO:0003212 ! T-lymphoma cell line
 [Term]
 id: BTO:0002294
 name: solid substrate culture
-def: "Cell culture on a solid material." [curators:mgr]
+def: "Cell culture on a solid material." []
 is_a: BTO:0000214 ! cell culture
+created_by: Marion Gremse
 
 [Term]
 id: BTO:0002295
@@ -16416,7 +16429,7 @@ synonym: "UCLA RO-81-A-1 cell" RELATED []
 synonym: "UCLA-RO 81 cell" RELATED []
 synonym: "UCLA-RO-81A-1 cell" RELATED []
 relationship: develops_from BTO:0000182 ! HT-29 cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-28T04:15:56Z
 
 [Term]
@@ -17158,7 +17171,7 @@ id: BTO:0002407
 name: spermary
 def: "An organ or a gland in which male gametes are formed, especially in invertebrate animals." [Dictionary:http\://www.thefreedictionary.com/]
 is_a: BTO:0000080 ! male reproductive gland
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-01-28T08:32:51Z
 
 [Term]
@@ -17237,7 +17250,7 @@ synonym: "helper T-cell" RELATED []
 synonym: "T helper cell" RELATED []
 synonym: "T4 cell" RELATED []
 is_a: BTO:0000782 ! T-lymphocyte
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-01-28T08:36:32Z
 
 [Term]
@@ -17972,7 +17985,7 @@ name: odontoclast
 def: "A large multinuclear cell associated with the absorption and removal of bone. It is cytomorphologically the same as an osteoclast and is involved in cementum resorption." [Medical_Dictionary_Online:http\://www.online-medical-dictionary.org/]
 synonym: "cementoclast" RELATED []
 relationship: part_of BTO:0000339 ! dental pulp
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-01-28T08:44:03Z
 
 [Term]
@@ -18031,7 +18044,7 @@ id: BTO:0002525
 name: cementum
 def: "The bonelike rigid connective tissue covering the root of a tooth from the cementoenamel junction to the apex and lining the apex of the root canal, also assisting in tooth support by serving as attachment structures for the periodontal ligament." [Medical_Dictionary_Online:http\://www.online-medical-dictionary.org/]
 relationship: part_of BTO:0001021 ! periodontium
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-01-28T08:46:22Z
 
 [Term]
@@ -18600,7 +18613,7 @@ synonym: "neuroglia cell" RELATED []
 synonym: "neuroglial cell" RELATED []
 relationship: part_of BTO:0000524 ! glia
 relationship: part_of BTO:0001279 ! spinal cord
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-01-28T08:55:00Z
 
 [Term]
@@ -18625,7 +18638,7 @@ synonym: "neuroglia cell" RELATED []
 synonym: "neuroglial cell" RELATED []
 is_a: BTO:0002606 ! glial cell
 relationship: part_of BTO:0003852 ! astroglia
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-01-28T08:56:44Z
 
 [Term]
@@ -18667,7 +18680,7 @@ id: BTO:0002615
 name: fascia dentata
 def: "The fascia dentata is the earliest stage of the hippocampal circuit. The fascia dentata and the hilus together make up the dentate gyrus." [Wikipedia:The_Free_Encyclopedia]
 relationship: part_of BTO:0002496 ! dentate gyrus
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-17T10:42:14Z
 
 [Term]
@@ -18741,7 +18754,7 @@ id: BTO:0002625
 name: mesenchymal cell
 def: "An undifferentiated cell found in mesenchyme and capable of differentiating into various specialized connective tissues." [Sci-Tech_Dictionary:http\://www.answers.com/]
 relationship: part_of BTO:0001393 ! mesenchyme
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-01-29T09:42:51Z
 
 [Term]
@@ -18822,7 +18835,7 @@ name: Hs 925.T cell
 def: "Human skin pagetoid sarcoma cell line." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 synonym: "Hs925T cell" RELATED []
 is_a: BTO:0000400 ! sarcoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-29T09:14:49Z
 
 [Term]
@@ -18861,7 +18874,7 @@ id: BTO:0002643
 name: cortical collecting duct
 def: "The cortical collecting ducts receive filtrate from multiple initial collecting tubules and descend into the renal medulla to form medullary collecting ducts." [Encyclopedia:http\://encyclopedia.thefreedictionary.com/]
 relationship: part_of BTO:0000761 ! collecting duct
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T10:22:01Z
 
 [Term]
@@ -18931,7 +18944,7 @@ id: BTO:0002653
 name: N2aEGFP cell
 def: "N2a cells stably expressing the vector pEGFP." [PMID:19117523]
 relationship: develops_from BTO:0001976 ! Neuro-2a cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-01-29T09:47:29Z
 
 [Term]
@@ -18996,7 +19009,7 @@ id: BTO:0002663
 name: N2aSW cell
 def: "N2a cells stably expressing human APP Swedish mutation." [PMID:19117523]
 relationship: develops_from BTO:0001976 ! Neuro-2a cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-01-29T09:48:52Z
 
 [Term]
@@ -19769,7 +19782,7 @@ synonym: "olfactory nerve ensheathing cell" RELATED []
 synonym: "ONEC cell" RELATED []
 is_a: BTO:0002606 ! glial cell
 relationship: part_of BTO:0000961 ! olfactory bulb
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-08-04T09:23:20Z
 
 [Term]
@@ -20917,7 +20930,7 @@ id: BTO:0002930
 name: fascia
 def: "A sheet of connective tissue covering or binding together body structures as muscles." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/fascia]
 is_a: BTO:0000421 ! connective tissue
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-01-29T10:03:29Z
 
 [Term]
@@ -21132,7 +21145,7 @@ def: "This line was isolated in 1968 and associates from a patient with stage IA
 synonym: "HEC-1A cell" RELATED []
 synonym: "HEC1A cell" RELATED []
 is_a: BTO:0003040 ! uterine adenocarcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-01-29T10:23:36Z
 
 [Term]
@@ -21438,9 +21451,10 @@ relationship: part_of BTO:0001421 ! uterine cervix
 [Term]
 id: BTO:0003003
 name: epididymal fluid
-def: "The fluid from the epididymis." [curators:mgr]
+def: "The fluid from the epididymis." []
 synonym: "epididymal luminal fluid" RELATED []
 relationship: develops_from BTO:0000408 ! epididymis
+created_by: Marion Gremse
 
 [Term]
 id: BTO:0003004
@@ -21660,7 +21674,7 @@ name: MT-4 cell
 def: "Human T cell Lymphotropic Virus-I (HTLV-I) carrying human T cell line." [PMID:1364232]
 synonym: "MT4 cell" RELATED []
 is_a: BTO:0001045 ! T-lymphocyte cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-08T09:33:37Z
 
 [Term]
@@ -21721,7 +21735,7 @@ def: "This is a substrain of HEC-1-A." [ATCC_American_Cell_Type_Culture_Collecti
 synonym: "HEC-1B cell" RELATED []
 synonym: "HEC1B cell" RELATED []
 relationship: develops_from BTO:0002960 ! HEC-1-A cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-01-29T10:24:37Z
 
 [Term]
@@ -22122,7 +22136,7 @@ id: BTO:0003094
 name: secondary oocyte
 def: "The immature reproductive cell prior to fertilization; it is derived from an oogonium, and is called a primary oocyte prior to completion of the first maturation division, and a secondary oocyte between the first and second maturation division." [Dorlands_Medical_Dictionary:MerckSource]
 is_a: BTO:0000964 ! oocyte
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-07-22T09:29:51Z
 
 [Term]
@@ -22130,7 +22144,7 @@ id: BTO:0003095
 name: normoblast
 def: "A nucleated red blood cell, the immediate precursor of a normal red blood cell in humans." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 is_a: BTO:0001441 ! marrow cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-07-22T09:55:14Z
 
 [Term]
@@ -22226,7 +22240,7 @@ id: BTO:0003108
 name: ChaGo-K-1 cell
 def: "Human lung bronchus carcinoma cell line, derived from a bronchogenic carcinoma of a 45-year-old male." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 is_a: BTO:0000762 ! lung cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-09-05T10:41:55Z
 
 [Term]
@@ -23242,7 +23256,7 @@ id: BTO:0003254
 name: DPK-SKDF-H cell
 def: "Normal human dermal fibroblast cell line." [PMID:17922656]
 is_a: BTO:0001619 ! skin fibroblast cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-28T04:31:48Z
 
 [Term]
@@ -23617,7 +23631,7 @@ id: BTO:0003305
 name: epipodite
 def: "The outer branch of the legs in certain Crustacea." [Mondofacto_Dictionary:http\://www.mondofacto.com/facts/dictionary?]
 relationship: part_of BTO:0000721 ! leg
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-01-29T11:02:36Z
 
 [Term]
@@ -23909,7 +23923,7 @@ id: BTO:0003347
 name: HEK-293 Tet-On 3G cell
 def: "HEK 293 Tet-On 3G is a transformed human embryonic kidney-derived cell line that expresses the tetracycline (Tet)- regulated transactivator Tet-On 3G." [Clontech:http\://www.clontech.com/US/Products/Inducible_Systems/Tetracycline-Inducible_Expression/Tet-On_3G_Cell_Lines]
 relationship: develops_from BTO:0000007 ! HEK-293 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-09-05T10:51:05Z
 
 [Term]
@@ -25026,7 +25040,7 @@ name: headfoot
 def: "The head-foot is the part you see most easily in slugs and snails. It is mostly a muscular organ covered in cilia and rich in mucous cells, which the mollusc uses to move around, it normally tapers to a tail at one end and has a head incorporated in the front. The head includes a mouth, eyes and tentacles, the last two may be much reduced or even absent. In those species with shells the head-foot can be drawn into the shell." [Molluscs_General_Anatomy:http\://www.earthlife.net/inverts/mollusca.html]
 synonym: "head-foot" RELATED []
 is_a: BTO:0001262 ! soft body part
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-01-29T11:19:54Z
 
 [Term]
@@ -25646,7 +25660,7 @@ name: renal parenchyma
 def: "The functional tissue of the kidney, consisting of the nephrons." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 synonym: "kidney parenchyma" RELATED []
 relationship: part_of BTO:0000671 ! kidney
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-01-29T11:24:56Z
 
 [Term]
@@ -25849,9 +25863,10 @@ relationship: develops_from BTO:0004013 ! Colon-26 cell
 [Term]
 id: BTO:0003632
 name: cervicovaginal fluid
-def: "The fluid of the uterine cervix and the vagina." [curators:mgr]
+def: "The fluid of the uterine cervix and the vagina." []
 relationship: part_of BTO:0000243 ! vagina
 relationship: part_of BTO:0001424 ! uterus
+created_by: Marion Gremse
 
 [Term]
 id: BTO:0003633
@@ -27150,7 +27165,7 @@ id: BTO:0003825
 name: neural crest cell
 def: "Neural crest cells are a temporary group of cells unique to vertebrates that arise from the embryonic ectoderm cell layer, and in turn give rise to a diverse cell lineage, including melanocytes craniofacial cartilage and bone, smooth muscle, peripheral and enteric neurons and glia." [Wikipedia:The_Free_Encyclopedia]
 relationship: part_of BTO:0001764 ! neural crest
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-28T08:59:50Z
 
 [Term]
@@ -28216,10 +28231,11 @@ is_a: BTO:0000786 ! tongue cancer cell line
 [Term]
 id: BTO:0003982
 name: retinal stem cell
-def: "Retinal progenitor cell." [curators:mgr]
+def: "Retinal progenitor cell." []
 synonym: "retinal progenitor cell" RELATED []
 is_a: BTO:0002881 ! neural stem cell
 is_a: BTO:0004091 ! embryonic neural stem cell
+created_by: Marion Gremse
 
 [Term]
 id: BTO:0003983
@@ -28771,8 +28787,9 @@ is_a: BTO:0001479 ! culture condition:-grown cell
 [Term]
 id: BTO:0004057
 name: fruit juice
-def: "Juice produced by squeezing or crushing fruit." [curators:mgr]
+def: "Juice produced by squeezing or crushing fruit." []
 is_a: BTO:0000659 ! juice
+created_by: Marion Gremse
 
 [Term]
 id: BTO:0004058
@@ -29106,7 +29123,7 @@ synonym: "insect labrum" RELATED []
 synonym: "labium" RELATED []
 synonym: "labrum" RELATED []
 relationship: part_of BTO:0001090 ! mouth
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-28T05:05:03Z
 
 [Term]
@@ -29277,7 +29294,7 @@ name: lung endothelium
 synonym: "respiratory endothelium" RELATED []
 is_a: BTO:0000393 ! endothelium
 is_a: BTO:0001653 ! lung epithelium
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-01-29T03:09:56Z
 
 [Term]
@@ -29779,7 +29796,7 @@ name: insect labellum
 def: "A terminal part of the labium or labrum of various insects." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/labellum]
 synonym: "labellum" RELATED []
 relationship: part_of BTO:0004104 ! insect labium
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-28T05:06:19Z
 
 [Term]
@@ -30189,7 +30206,7 @@ def: "In limbs of vertebrate animals. A long cylindrical bone that contains marr
 synonym: "os longum" RELATED SCI []
 is_a: BTO:0000140 ! bone
 relationship: part_of BTO:0001492 ! limb
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-01-29T03:14:18Z
 
 [Term]
@@ -31123,7 +31140,7 @@ id: BTO:0004395
 name: microvessel
 def: "A blood vessel as a capillary, arteriole, or venule of the microcirculatory system." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/microvessel]
 is_a: BTO:0001102 ! blood vessel
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-01-29T03:21:57Z
 
 [Term]
@@ -31131,7 +31148,7 @@ id: BTO:0004396
 name: femorotibial joint
 def: "One of the two primary bendings of a typical leg, pertains to the femur and the tibia." [Online_Dictionary_of_Invertebrate_Zoology:http\://digitalcommons.unl.edu/cgi/viewcontent.cgi?article=1017&context=onlinedictinvertzoology]
 relationship: part_of BTO:0000721 ! leg
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-01-29T03:32:00Z
 
 [Term]
@@ -31140,14 +31157,14 @@ name: B-103 cell
 def: "Rat neuroblastoma cell line." [PMID:3729390]
 synonym: "B103 cell" RELATED []
 is_a: BTO:0000932 ! neuroblastoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T09:37:13Z
 
 [Term]
 id: BTO:0004398
 name: meningioma cell line
 relationship: develops_from BTO:0001756 ! meningioma cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T09:41:16Z
 
 [Term]
@@ -31155,7 +31172,7 @@ id: BTO:0004399
 name: BEN-MEN-1 cell
 def: "Human benign meningioma cell line; established in 2003 from the meningothelial meningioma grade I attached to the parietal falx of a 68-year-old woman after surgical tumor resection; cells were immortalized by retroviral transduction with human telomerase reverse transcriptase." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 is_a: BTO:0004398 ! meningioma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T09:41:36Z
 
 [Term]
@@ -31164,7 +31181,7 @@ name: BPAEC cell
 def: "Bovine pulmonary artery endothelial cell line." [Invitrogen:http\://products.invitrogen.com/]
 synonym: "bovine pulmonary artery endothelial cell" RELATED []
 is_a: BTO:0003150 ! pulmonary artery endothelial cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T09:56:53Z
 
 [Term]
@@ -31173,21 +31190,21 @@ name: bronchial smooth muscle
 def: "Smooth muscle that is present continuously around the bronchi." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0001660 ! respiratory smooth muscle
 relationship: part_of BTO:0001340 ! bronchus
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T10:00:49Z
 
 [Term]
 id: BTO:0004402
 name: bronchial smooth muscle cell
 relationship: part_of BTO:0004401 ! bronchial smooth muscle
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T10:02:33Z
 
 [Term]
 id: BTO:0004403
 name: tracheal smooth muscle cell
 relationship: part_of BTO:0001391 ! tracheal smooth muscle
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T10:02:53Z
 
 [Term]
@@ -31195,7 +31212,7 @@ id: BTO:0004404
 name: BL-3 cell
 def: "Bovine lymphoblastoid cell line." [PMID:16113266]
 is_a: BTO:0000773 ! lymphoblastoid cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T10:07:05Z
 
 [Term]
@@ -31203,7 +31220,7 @@ id: BTO:0004405
 name: 3D5 cell
 def: "Human B-cell line." [PMID:18726349]
 is_a: BTO:0001522 ! B-lymphocyte cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T10:12:01Z
 
 [Term]
@@ -31211,7 +31228,7 @@ id: BTO:0004406
 name: CABA I cell
 def: "Human ovarian cancer cell line; established from ascitic fluid obtained from a patient with papillary adenocarcinoma of the ovary prior to drug treatment." [PMID:9220498]
 is_a: BTO:0000811 ! ovary cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T10:34:19Z
 
 [Term]
@@ -31219,7 +31236,7 @@ id: BTO:0004407
 name: CB33 cell
 def: "Epstein-Barr virus immortalized B-lymphoblastoid cell line." [PMID:1586717]
 is_a: BTO:0002062 ! B-lymphoblastoid cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T10:44:13Z
 
 [Term]
@@ -31227,7 +31244,7 @@ id: BTO:0004408
 name: culture condition:CD34+ cell
 def: "Cells expressing CD34 are normally found in the umbilical cord and bone marrow as hematopoietic cells, a subset of mesenchymal stem cells, endothelial progenitor cells, endothelial cells of blood vessels but not lymphatics, except pleural lymphatics, mast cells, a sub-population dendritic cells in the interstitium and around the adnexa of dermis of skin, as well as cells in soft tissue tumors." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0002008 ! culture condition:antigen-presenting cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T10:53:27Z
 
 [Term]
@@ -31235,7 +31252,7 @@ id: BTO:0004409
 name: culture condition:CD68+ cell
 def: "CD68 is used to identify macrophages and giant cells." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0002008 ! culture condition:antigen-presenting cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T11:00:37Z
 
 [Term]
@@ -31243,14 +31260,14 @@ id: BTO:0004410
 name: culture condition:CD8+ cell
 def: "The CD8 co-receptor is predominantly expressed on the surface of cytotoxic T cells, but can also be found on natural killer cells and dendritic cells." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0002008 ! culture condition:antigen-presenting cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T11:01:31Z
 
 [Term]
 id: BTO:0004411
 name: culture condition:CD8- cell
 is_a: BTO:0002008 ! culture condition:antigen-presenting cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T11:03:35Z
 
 [Term]
@@ -31258,7 +31275,7 @@ id: BTO:0004412
 name: oral lichen planus disease specific cell type
 def: "Oral lesions accompanying cutaneous lichen planus or often occurring alone. The buccal mucosa, lips, gingivae, floor of the mouth, and palate are usually affected. Typically, oral lesions consist of radiating white or gray, velvety, threadlike lines, arranged in a reticular pattern, at the intersection of which there may be minute, white, elevated dots or streaks named wickhams striae." [Mondofacto_Dictionary:http\://www.mondofacto.com/facts/dictionary?]
 relationship: disease_causes_dysfunction_of BTO:0001090 ! mouth
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T11:12:04Z
 
 [Term]
@@ -31266,7 +31283,7 @@ id: BTO:0004413
 name: CJ7 cell
 def: "Murine embryonic stem cell line." [PMID:19508153]
 is_a: BTO:0001581 ! embryonic stem cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T11:56:02Z
 
 [Term]
@@ -31274,7 +31291,7 @@ id: BTO:0004414
 name: KH2 cell
 def: "Murine embryonic stem cell line." [PMID:19508153]
 is_a: BTO:0001581 ! embryonic stem cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T11:56:40Z
 
 [Term]
@@ -31283,7 +31300,7 @@ name: DM-4 cell
 def: "Human melanoma cell line highly metastatic in nude mice." [PMID:9271321]
 synonym: "DM4 cell" RELATED []
 is_a: BTO:0000849 ! melanoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T12:11:54Z
 
 [Term]
@@ -31292,7 +31309,7 @@ name: Daltons lymphoma cell
 def: "Spontaneous T cell lymphoma." [PMID:12937840]
 synonym: "Dalton's lymphoma cell" RELATED []
 is_a: BTO:0001825 ! T-cell lymphoma cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T01:24:28Z
 
 [Term]
@@ -31301,7 +31318,7 @@ name: Daltons lymphoma ascites cell
 synonym: "Dalton's lymphoma ascites cell" RELATED []
 synonym: "DLA cell" RELATED []
 is_a: BTO:0004416 ! Daltons lymphoma cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T01:29:41Z
 
 [Term]
@@ -31309,7 +31326,7 @@ id: BTO:0004418
 name: Daltons lymphoma ascites
 synonym: "Dalton's lymphoma ascites" RELATED []
 relationship: produced_by BTO:0004416 ! Daltons lymphoma cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T01:30:47Z
 
 [Term]
@@ -31318,7 +31335,7 @@ name: dermal fibroblast
 def: "Dermal fibroblasts are the major cell type in dermis and are commonly accepted as terminally differentiated cells." [Cell_Research_(2008):Dermal_fibroblasts\,_an_old_population_in_new_environments]
 is_a: BTO:0001255 ! skin fibroblast
 relationship: part_of BTO:0000294 ! dermis
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T01:35:22Z
 
 [Term]
@@ -31326,7 +31343,7 @@ id: BTO:0004420
 name: digestive cell
 def: "Three cell types are present in tubules of the digestive gland of the marine prosobranch Maoricrypta monoxyla. Histochemistry, and feeding and starvation experiments established that the main type, the digestive cell, is involved in endocytotic uptake of food material from the lumen." [J._Moll._Stud._(1979)\,_45\,_262-283:Cyclic_activity_and_epithelial_renewal_in_the_digestive_gland_tubules_of_the_marine_prosobranch_maoricrypta_monoxyla_(Lesson)]
 relationship: part_of BTO:0000345 ! digestive gland
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T01:42:56Z
 
 [Term]
@@ -31334,7 +31351,7 @@ id: BTO:0004421
 name: salivary gland epithelium
 is_a: BTO:0000416 ! epithelium
 relationship: part_of BTO:0001203 ! salivary gland
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T01:55:57Z
 
 [Term]
@@ -31342,7 +31359,7 @@ id: BTO:0004422
 name: pleural cavity
 def: "The space enclosed by the pleura, which is a thin layer of tissue that covers the lungs and lines the interior wall of the chest cavity." [Dictionary_of_Cancer_Terms:http\://www.cancer.gov/]
 relationship: part_of BTO:0000763 ! lung
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T02:05:38Z
 
 [Term]
@@ -31351,7 +31368,7 @@ name: empyema fluid
 def: "The presence of pus in a body cavity, especially the pleural cavity." [Dictionary:http\://www.thefreedictionary.com/]
 synonym: "empyema" RELATED []
 relationship: disease_causes_dysfunction_of BTO:0004422 ! pleural cavity
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T02:06:20Z
 
 [Term]
@@ -31360,7 +31377,7 @@ name: ES-2 cell
 def: "Human clear cell ovarian carcinoma cell line." [PMID:12298089]
 synonym: "ES2 cell" RELATED []
 is_a: BTO:0000811 ! ovary cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T02:11:00Z
 
 [Term]
@@ -31370,7 +31387,7 @@ def: "The deepest of the three layers of the cortex; it contains large numbers o
 synonym: "granular layer of cerebellar cortex" RELATED []
 synonym: "granular layer of cerebellum" RELATED []
 relationship: part_of BTO:0000043 ! cerebellar cortex
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T05:12:36Z
 
 [Term]
@@ -31379,7 +31396,7 @@ name: NCI-H1915 cell
 def: "Human non-small cell lung cancer cell line." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 synonym: "H1915 cell" RELATED []
 is_a: BTO:0002553 ! non-small cell lung cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T05:23:39Z
 
 [Term]
@@ -31388,7 +31405,7 @@ name: NCI-H211 cell
 def: "Human small cell lung cancer cell line." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 synonym: "H211 cell" RELATED []
 is_a: BTO:0002206 ! small cell lung cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T05:26:36Z
 
 [Term]
@@ -31411,7 +31428,7 @@ synonym: "Reuber-H-35 hepatoma cell" RELATED []
 synonym: "Reuber-H35 hepatoma cell" RELATED []
 synonym: "RH-35 cell" RELATED []
 is_a: BTO:0000578 ! hepatoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T07:45:29Z
 
 [Term]
@@ -31420,7 +31437,7 @@ name: H-59 cell
 def: "Highly invasive Lewis lung carcinoma subline." [PMID:12592384]
 synonym: "H59 cell" RELATED []
 is_a: BTO:0000181 ! Lewis lung carcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T07:51:27Z
 
 [Term]
@@ -31428,14 +31445,14 @@ id: BTO:0004430
 name: HBL-52 cell
 def: "The cell line was originally taken from a transitional meningioma grade I localized at the optic canal." [CLS-Cell_Lines_Service:http\://www.cell-lines-service.de/]
 is_a: BTO:0004398 ! meningioma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T07:54:00Z
 
 [Term]
 id: BTO:0004431
 name: coronary artery endothelial cell line
 relationship: develops_from BTO:0004096 ! coronary artery endothelial cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T07:57:10Z
 
 [Term]
@@ -31443,7 +31460,7 @@ id: BTO:0004432
 name: HCAEC cell
 def: "Human coronary artery endothelial cell line." [PMID:16502366]
 is_a: BTO:0004431 ! coronary artery endothelial cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-01T07:57:59Z
 
 [Term]
@@ -31452,7 +31469,7 @@ name: HET-1A cell
 def: "Human esophageal cell line; derived in 1986 from human esophageal autopsy tissue by transfection with plasmid pRSV-T consisting of the RSV-LTR promoter and the sequence encoding the simian virus 40 large T-antigen." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 synonym: "HET1A cell" RELATED []
 is_a: BTO:0003640 ! esophageal cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-02T02:40:45Z
 
 [Term]
@@ -31462,7 +31479,7 @@ def: "Human normal mammary epithelial cell line." [WO/2007/095583:Methods_for_tr
 synonym: "HMEC 1330 cell" RELATED []
 synonym: "HMEC1330 cell" RELATED []
 is_a: BTO:0002768 ! mammary epithelial cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-02T02:48:52Z
 
 [Term]
@@ -31471,7 +31488,7 @@ name: HOSE 11-12 cell
 def: "Human ovarian surface epithelial cell line, expressing HPV 16 E6E7, donor age 49 years." [PMID:15489894]
 synonym: "HOSE11-12 cell" RELATED []
 is_a: BTO:0002555 ! HOSE cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-02T02:54:22Z
 
 [Term]
@@ -31480,7 +31497,7 @@ name: HOSE 6-3 cell
 def: "Immortalized non-cancer human ovarian surface epithelial cell line." [PMID:18430509]
 synonym: "HOSE6-3 cell" RELATED []
 is_a: BTO:0002555 ! HOSE cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-02T02:58:14Z
 
 [Term]
@@ -31489,7 +31506,7 @@ name: HOSE 17-1 cell
 def: "Normal human ovarian surface epithelial cell line." [PMID:18796737]
 synonym: "HOSE17-1 cell" RELATED []
 is_a: BTO:0002555 ! HOSE cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-02T03:01:39Z
 
 [Term]
@@ -31499,7 +31516,7 @@ def: "Human squamous cell carcinoma cell line." [PMID:16956683]
 synonym: "hSCC cell" RELATED []
 synonym: "human SCC cell" RELATED []
 is_a: BTO:0002024 ! squamous cell carcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-02T03:08:47Z
 
 [Term]
@@ -31507,7 +31524,7 @@ id: BTO:0004439
 name: hypopharyngeal carcinoma cell line
 is_a: BTO:0000790 ! pharyngeal cancer cell line
 relationship: develops_from BTO:0001740 ! hypopharynx
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-02T03:17:50Z
 
 [Term]
@@ -31515,7 +31532,7 @@ id: BTO:0004440
 name: UT-SCC-14 cell
 def: "Human squamous cell carcinoma cell line." [PMID:16956683]
 is_a: BTO:0004438 ! HSCC cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-02T03:10:53Z
 
 [Term]
@@ -31523,7 +31540,7 @@ id: BTO:0004441
 name: UT-SCC-15 cell
 def: "Human squamous cell carcinoma cell line." [PMID:16956683]
 is_a: BTO:0004438 ! HSCC cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-02T03:11:19Z
 
 [Term]
@@ -31531,7 +31548,7 @@ id: BTO:0004442
 name: UT-SCC-5 cell
 def: "Human squamous cell carcinoma cell line." [PMID:16956683]
 is_a: BTO:0004438 ! HSCC cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-02T03:12:12Z
 
 [Term]
@@ -31539,7 +31556,7 @@ id: BTO:0004443
 name: XF354 cell
 def: "Human squamous cell carcinoma cell line." [PMID:16956683]
 is_a: BTO:0004438 ! HSCC cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-02T03:12:34Z
 
 [Term]
@@ -31547,7 +31564,7 @@ id: BTO:0004444
 name: HUVE-12 cell
 def: "Human umbilical vein endothelial cell line." [PMID:19182385]
 is_a: BTO:0001949 ! HUVEC cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-02T03:26:02Z
 
 [Term]
@@ -31556,7 +31573,7 @@ name: IB3-1 cell
 def: "Immortalized cell line created in 1992 from a primary culture of bronchial epithelial cells isolated from a patient with cystic fibrosis." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 synonym: "JHU-52 cell" RELATED []
 is_a: BTO:0002022 ! bronchial epithelial cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-02T03:29:13Z
 
 [Term]
@@ -31565,7 +31582,7 @@ name: S9 cell
 def: "The S9 cell line and the C38 cell line were derived from the IB3-1 cell line." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 synonym: "JHU-53 cell" RELATED []
 relationship: develops_from BTO:0004445 ! IB3-1 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-02T03:35:11Z
 
 [Term]
@@ -31574,7 +31591,7 @@ name: C38 cell
 def: "The S9 cell line and the C38 cell line were derived from the IB3-1 cell line." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 synonym: "JHU-54 cell" RELATED []
 relationship: develops_from BTO:0004445 ! IB3-1 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-02T03:36:28Z
 
 [Term]
@@ -31583,7 +31600,7 @@ name: LN-235 cell
 def: "Human glioblastoma cell line." [PMID:7693337]
 synonym: "LN235 cell" RELATED []
 is_a: BTO:0001530 ! glioblastoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-02T03:41:14Z
 
 [Term]
@@ -31593,7 +31610,7 @@ def: "Human glioblastoma cell line." [PMID:7693337]
 comment: Contaminated. Shown to be a LN-444 derivative.
 synonym: "LN443 cell" RELATED []
 relationship: develops_from BTO:0004450 ! LN-444 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-02T03:45:33Z
 
 [Term]
@@ -31602,7 +31619,7 @@ name: LN-444 cell
 def: "Human glioblastoma cell line." [PMID:7693337]
 synonym: "LN444 cell" RELATED []
 is_a: BTO:0001530 ! glioblastoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-02T03:45:51Z
 
 [Term]
@@ -31611,7 +31628,7 @@ name: LN-464 cell
 def: "Human glioblastoma cell line." [PMID:7693337]
 synonym: "LN464 cell" RELATED []
 is_a: BTO:0001530 ! glioblastoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-02T03:46:07Z
 
 [Term]
@@ -31620,7 +31637,7 @@ name: LN-702 cell
 def: "Human glioblastoma cell line." [PMID:7693337]
 synonym: "LN702 cell" RELATED []
 is_a: BTO:0001530 ! glioblastoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-02T03:46:30Z
 
 [Term]
@@ -31629,7 +31646,7 @@ name: LN-751 cell
 def: "Human glioblastoma cell line." [PMID:7693337]
 synonym: "LN751 cell" RELATED []
 is_a: BTO:0001530 ! glioblastoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-02T03:46:46Z
 
 [Term]
@@ -31638,7 +31655,7 @@ name: LN-774 cell
 def: "Human glioblastoma cell line." [PMID:7693337]
 synonym: "LN774 cell" RELATED []
 is_a: BTO:0001530 ! glioblastoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-02T03:47:14Z
 
 [Term]
@@ -31647,7 +31664,7 @@ name: LN-784 cell
 def: "Human glioblastoma cell line." [PMID:7693337]
 synonym: "LN784 cell" RELATED []
 is_a: BTO:0001530 ! glioblastoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-02T03:47:30Z
 
 [Term]
@@ -31656,7 +31673,7 @@ name: LN-215 cell
 def: "Human glioblastoma cell line." [PMID:7693337]
 synonym: "LN215 cell" RELATED []
 is_a: BTO:0001530 ! glioblastoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-02T03:48:13Z
 
 [Term]
@@ -31668,7 +31685,7 @@ synonym: "LN308 cell" RELATED []
 synonym: "LNZ-308 cell" RELATED []
 synonym: "LNZ308 cell" RELATED []
 is_a: BTO:0001530 ! glioblastoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-02T03:48:30Z
 
 [Term]
@@ -31677,7 +31694,7 @@ name: LN-340 cell
 def: "Human glioblastoma cell line." [PMID:7693337]
 synonym: "LN340 cell" RELATED []
 is_a: BTO:0001530 ! glioblastoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-02T03:48:58Z
 
 [Term]
@@ -31686,7 +31703,7 @@ name: LN-382 cell
 def: "Human glioblastoma cell line." [PMID:7693337]
 synonym: "LN382 cell" RELATED []
 is_a: BTO:0001530 ! glioblastoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-02T03:49:16Z
 
 [Term]
@@ -31704,7 +31721,7 @@ name: KYSE-30 cell
 def: "Well differentiated human squamous cell carcinoma from esophageal cancer." [Japanese_Collection_of_Research_Bioresources:http\://cellbank.nibio.go.jp/]
 synonym: "KYSE30 cell" RELATED []
 is_a: BTO:0002428 ! esophageal squamous cell carcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-02T03:58:53Z
 
 [Term]
@@ -31713,7 +31730,7 @@ name: K-562R cell
 def: "Imatinib resistant subline of K562." [PMID:17294720]
 synonym: "K562R cell" RELATED []
 relationship: develops_from BTO:0000664 ! K-562 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-02T04:01:32Z
 
 [Term]
@@ -31721,7 +31738,7 @@ id: BTO:0004463
 name: ileostomal fluid
 def: "Ileostomy is the artificial opening made by the surgical formation of an artificial anus by connecting the ileum to an opening in the abdominal wall." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/ileostomy]
 relationship: realized_in BTO:0000620 ! ileum
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-03T10:04:46Z
 
 [Term]
@@ -31729,7 +31746,7 @@ id: BTO:0004464
 name: IOMM-Lee cell
 def: "Malignant meningioma cell line." [PMID:19082492]
 is_a: BTO:0004398 ! meningioma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-03T10:24:13Z
 
 [Term]
@@ -31738,7 +31755,7 @@ name: LAMA-84 cell
 def: "Human chronic myeloid leukemia in blast crisis; established from the peripheral blood of a 29-year-old woman with chronic myeloid leukemia." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 synonym: "LAMA84 cell" RELATED []
 is_a: BTO:0002580 ! chronic myeloid leukemia cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-03T11:41:03Z
 
 [Term]
@@ -31746,7 +31763,7 @@ id: BTO:0004466
 name: LAMA-87 cell
 def: "Human chronic myeloid leukemia in blast crisis, derivative of LAMA-84; subclone LAMA-87 was obtained after subcutaneous transplantation of LAMA-84 cells into estrone-treated nude mice." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 relationship: develops_from BTO:0004465 ! LAMA-84 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-03T11:43:05Z
 
 [Term]
@@ -31754,7 +31771,7 @@ id: BTO:0004467
 name: LbetaT2 cell
 def: "Murine pituitary gonadotrope cell line." [PMID:11524240]
 is_a: BTO:0000427 ! pituitary gland cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-04T09:45:37Z
 
 [Term]
@@ -31762,7 +31779,7 @@ id: BTO:0004468
 name: lip epithelium
 is_a: BTO:0000416 ! epithelium
 relationship: part_of BTO:0001647 ! lip
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-04T09:50:12Z
 
 [Term]
@@ -31774,7 +31791,7 @@ synonym: "LM3 cell" RELATED []
 synonym: "MHCC-LM3 cell" RELATED []
 synonym: "MHCCLM-3 cell" RELATED []
 relationship: develops_from BTO:0004169 ! MHCC97-H cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-04T10:02:09Z
 
 [Term]
@@ -31784,7 +31801,7 @@ def: "Hepatocellular carcinoma cell line." [PMID:19335983]
 synonym: "HCCLM6 cell" RELATED []
 synonym: "LM6 cell" RELATED []
 relationship: develops_from BTO:0004469 ! HCCLM-3 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-04T10:03:31Z
 
 [Term]
@@ -31792,7 +31809,7 @@ id: BTO:0004471
 name: Mahlavu cell
 def: "Human hepatocellular carcinoma cell line." [PMID:16491122]
 is_a: BTO:0000578 ! hepatoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-04T10:16:05Z
 
 [Term]
@@ -31801,7 +31818,7 @@ name: mantle cell lymphoma cell
 def: "Mantle cell lymphoma is one of the rarest of the non-Hodgkin's lymphomas, comprising about 6% of NHL cases. It is a subtype of B-cell lymphoma, due to CD5 positive antigen-naive pregerminal center B-cell within the mantle zone that surrounds normal germinal center follicles." [Wikipedia:The_Free_Encyclopedia]
 synonym: "MCL cell" RELATED []
 is_a: BTO:0002904 ! non-Hodgkin lymphoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-04T10:18:47Z
 
 [Term]
@@ -31810,7 +31827,7 @@ name: MC3T3-E1(C4) cell
 def: "Calvarial osteoblastic cell line." [PMID:16546821]
 synonym: "MC3T3E1(C4) cell" RELATED []
 relationship: develops_from BTO:0001957 ! MC3T3-E1 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-04T10:26:11Z
 
 [Term]
@@ -31818,7 +31835,7 @@ id: BTO:0004474
 name: MDA-MB-231-BAG cell
 def: "Human breast cancer cell line." [PMID:15065599]
 relationship: develops_from BTO:0000815 ! MDA-MB-231 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-04T10:30:08Z
 
 [Term]
@@ -31828,7 +31845,7 @@ def: "Murine erythroleukemia cell line." [PMID:6575972]
 comment: Seems to be a synonym of MEL-745A cell.
 synonym: "murine erythroleukemia cell line" RELATED []
 is_obsolete: true
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-04T10:43:43Z
 
 [Term]
@@ -31837,7 +31854,7 @@ name: MES-23.5 cell
 def: "The MES 23.5 cells were derived from somatic cell fusion of rat embryonic mesencephalic cells with murine N18TG2 neuroblastoma cells." [PMID:19617199]
 synonym: "MES 23.5 cell" RELATED []
 relationship: develops_from BTO:0000933 ! N18TG2 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-04T10:50:40Z
 
 [Term]
@@ -31845,7 +31862,7 @@ id: BTO:0004477
 name: medial temporal lobe
 def: "The medial temporal lobes are near the Sagittal plane that divides left and right cerebral hemispheres and are thought to be involved in episodic, declarative memory." [Wikipedia:The_Free_Encyclopedia]
 relationship: part_of BTO:0001355 ! temporal lobe
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-04T10:57:44Z
 
 [Term]
@@ -31853,7 +31870,7 @@ id: BTO:0004478
 name: mucosal melanoma cell
 def: "Mucosal melanoma is a rare cutaneous condition characterized by a melanoma of the mucous membranes." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0000848 ! melanoma cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-04T11:04:15Z
 
 [Term]
@@ -31862,7 +31879,7 @@ name: MV4-11 cell
 def: "Human acute myelocytic leukemia cell line." [CLS-Cell_Lines_Service:http\://www.cell-lines-service.de/]
 comment: Is a synonym of BTO:0006413, name: MV-4-11 cell.
 is_obsolete: true
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-04T11:07:29Z
 
 [Term]
@@ -31872,7 +31889,7 @@ def: "The nasopharynx is lined by stratified squamous epithelium and respiratory
 synonym: "nasopharyngeal epithelium" RELATED []
 is_a: BTO:0000416 ! epithelium
 relationship: part_of BTO:0000662 ! nasopharynx
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-04T11:26:20Z
 
 [Term]
@@ -31880,7 +31897,7 @@ id: BTO:0004481
 name: neural crest-derived stem cell
 synonym: "NCSC cell" RELATED []
 is_a: BTO:0004091 ! embryonic neural stem cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-04T11:38:53Z
 
 [Term]
@@ -31888,21 +31905,21 @@ id: BTO:0004482
 name: ovarian surface epithelial cell line
 synonym: "OSE cell" RELATED []
 is_a: BTO:0004129 ! ovary epithelium cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-04T12:00:49Z
 
 [Term]
 id: BTO:0004483
 name: ovarian surface epithelium
 is_a: BTO:0003661 ! ovary epithelium
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-04T12:03:36Z
 
 [Term]
 id: BTO:0004484
 name: ovarian surface epithelial cell
 relationship: part_of BTO:0004483 ! ovarian surface epithelium
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-04T12:04:07Z
 
 [Term]
@@ -31910,7 +31927,7 @@ id: BTO:0004485
 name: OV-MZ-10 cell
 def: "Human ovarian cell line." [PMID:7510115]
 is_a: BTO:0000977 ! ovary cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-04T12:05:41Z
 
 [Term]
@@ -31918,7 +31935,7 @@ id: BTO:0004486
 name: OV-MZ-15 cell
 def: "Human ovarian cell line." [PMID:7510115]
 is_a: BTO:0000977 ! ovary cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-04T12:06:20Z
 
 [Term]
@@ -31926,7 +31943,7 @@ id: BTO:0004487
 name: OV-MZ-6 cell
 def: "Human ovarian cancer cell line." [PMID:19334037]
 is_a: BTO:0000811 ! ovary cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-04T12:07:17Z
 
 [Term]
@@ -31935,7 +31952,7 @@ name: NSC-34 cell
 def: "NSC-34 is a hybrid cell line, produced by fusion of motor neuron enriched, embryonic mouse spinal cord cells with mouse neuroblastoma." [Cellution_Systems_Inc.:Mouse_Motor_Neuron_NSC-34_Cell_Line_Maintenance]
 synonym: "NSC34 cell" RELATED []
 is_a: BTO:0000932 ! neuroblastoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-04T05:09:04Z
 
 [Term]
@@ -31944,7 +31961,7 @@ name: OE-21 cell
 def: "Esophageal cancer cell line." [PMID:19809435]
 synonym: "OE21 cell" RELATED []
 is_a: BTO:0002817 ! esophageal cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-04T05:19:45Z
 
 [Term]
@@ -31954,7 +31971,7 @@ def: "Rat fetal lung fibroblast cell line." [PMID:15509664]
 synonym: "RFL6 cell" RELATED []
 is_a: BTO:0000161 ! lung fibroblast cell line
 is_a: BTO:0001242 ! fetal cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-04T05:31:44Z
 
 [Term]
@@ -31965,14 +31982,14 @@ synonym: "RL-95 cell" RELATED []
 synonym: "RL-95-2 cell" RELATED []
 synonym: "RL95 cell" RELATED []
 is_a: BTO:0001555 ! endometrial cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-04T05:35:58Z
 
 [Term]
 id: BTO:0004492
 name: gastric epithelial cell
 relationship: part_of BTO:0000500 ! gastric epithelium
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-04T05:38:50Z
 
 [Term]
@@ -31982,7 +31999,7 @@ synonym: "gastric epithelial cell line" RELATED []
 is_a: BTO:0001088 ! gastric cell line
 is_a: BTO:0001120 ! epithelial cell line
 relationship: develops_from BTO:0000500 ! gastric epithelium
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-04T05:39:24Z
 
 [Term]
@@ -31990,7 +32007,7 @@ id: BTO:0004494
 name: RGM-1 cell
 def: "Normal rat gastric epithelial cell line." [PMID:20104269]
 is_a: BTO:0004493 ! gastric epithelium cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-04T05:39:49Z
 
 [Term]
@@ -31999,7 +32016,7 @@ name: SIRC cell
 def: "Rabbit corneal fibroblast cell line." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 synonym: "Statens Seruminstitut Rabbit Cornea cell" RELATED []
 is_a: BTO:0003346 ! corneal fibroblast cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-04T05:51:28Z
 
 [Term]
@@ -32007,7 +32024,7 @@ id: BTO:0004496
 name: preosteoclast
 def: "Precursors of an osteoclast." [PMID:3135092]
 relationship: part_of BTO:0000140 ! bone
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-04T05:56:25Z
 
 [Term]
@@ -32016,7 +32033,7 @@ name: WT-51 cell
 def: "Human B-lymphoblastoid cell line." [PMID:14966190]
 synonym: "WT51 cell" RELATED []
 is_a: BTO:0002062 ! B-lymphoblastoid cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-04T06:02:50Z
 
 [Term]
@@ -32024,7 +32041,7 @@ id: BTO:0004498
 name: THCE cell
 def: "Telomerase-immortalized human corneal epithelial cell line." [PMID:17543179]
 is_a: BTO:0003221 ! corneal cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-04T06:09:34Z
 
 [Term]
@@ -32036,7 +32053,7 @@ synonym: "PIN cell line" RELATED []
 synonym: "prostate intraepithelial neoplasia cell line" RELATED []
 synonym: "prostatic intraepithelial neoplasia cell line" RELATED []
 is_a: BTO:0002398 ! prostate epithelium cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-08T12:08:40Z
 
 [Term]
@@ -32045,7 +32062,7 @@ name: R1 cell
 def: "Mouse embryonic stem cell line; established from a 3.5 day blastocyst produced by crossing two 129 substrains, 129S1/SvImJ and 129X1/SvJ." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 synonym: "R1 ES cell" RELATED []
 is_a: BTO:0001581 ! embryonic stem cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-08T12:27:38Z
 
 [Term]
@@ -32053,7 +32070,7 @@ id: BTO:0004501
 name: plant vascular cell
 def: "Plant vascular cells originate from procambial cells, which are vascular stem cells." [PMID:15122351]
 is_a: BTO:0001432 ! vascular tissue
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-08T12:42:37Z
 
 [Term]
@@ -32061,7 +32078,7 @@ id: BTO:0004502
 name: vascular cambium
 def: "Cambium that produces secondary phloem on its outer side and secondary xylem on its inner side." [A_Dictionary_of_Plant_Sciences:http\://www.encyclopedia.com/]
 is_a: BTO:0000170 ! cambium
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-08T12:48:00Z
 
 [Term]
@@ -32078,7 +32095,7 @@ name: root vascular cell
 synonym: "root vasculature cell" RELATED []
 is_a: BTO:0004501 ! plant vascular cell
 relationship: part_of BTO:0001188 ! root
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-08T12:52:13Z
 
 [Term]
@@ -32087,7 +32104,7 @@ name: RS4-11 cell
 def: "Human B cell precursor leukemia cell line; established from the bone marrow of a 32-year-old woman with acute lymphoblastic leukemia (ALL L2) in first relapse." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 synonym: "RS4 11 cell" RELATED []
 is_a: BTO:0000603 ! pre-B acute lymphoblastic leukemia cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2010-02-08T12:59:21Z
 
 [Term]
@@ -32096,7 +32113,7 @@ name: RT-2 cell
 def: "Rat glioblastoma cell line." [PMID:9316053]
 synonym: "RT2 cell" RELATED []
 is_a: BTO:0001530 ! glioblastoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-08T01:18:20Z
 
 [Term]
@@ -32104,7 +32121,7 @@ id: BTO:0004507
 name: sEnd-1 cell
 def: "Murine vascular endothelial cell line." [PMID:10960079]
 is_a: BTO:0001973 ! vascular endothelial cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-08T04:32:54Z
 
 [Term]
@@ -32112,7 +32129,7 @@ id: BTO:0004508
 name: endothelioma cell
 def: "A tumor developing from endothelial tissue." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/endothelioma]
 relationship: develops_from BTO:0000393 ! endothelium
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-08T04:41:49Z
 
 [Term]
@@ -32120,7 +32137,7 @@ id: BTO:0004509
 name: endothelioma cell line
 relationship: develops_from BTO:0001519 ! endothelial cell line
 relationship: develops_from BTO:0004508 ! endothelioma cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-08T04:44:54Z
 
 [Term]
@@ -32129,7 +32146,7 @@ name: cystadenocarcinoma cell
 def: "A malignant neoplasm derived from glandular epithelium, in which cystic accumulations of retained secretions are formed. Cystadenocarcinomas develop frequently in the ovaries, where pseudomucinous and serous types are recognised." [Biology-Online_Dictionary:http\://www.biology-online.org/dictionary/]
 is_a: BTO:0001023 ! ovary cancer cell
 relationship: develops_from BTO:0002991 ! glandular epithelium
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-08T04:55:53Z
 
 [Term]
@@ -32137,7 +32154,7 @@ id: BTO:0004511
 name: serous cystadenocarcinoma cell
 def: "Cystadenocarcinomas develop frequently in the ovaries, where pseudomucinous and serous types are recognised." [Biology-Online_Dictionary:http\://www.biology-online.org/dictionary/]
 is_a: BTO:0004510 ! cystadenocarcinoma cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-08T04:57:22Z
 
 [Term]
@@ -32145,7 +32162,7 @@ id: BTO:0004512
 name: pseudomucinous cystadenocarcinoma cell
 def: "Cystadenocarcinomas develop frequently in the ovaries, where pseudomucinous and serous types are recognised." [Biology-Online_Dictionary:http\://www.biology-online.org/dictionary/]
 is_a: BTO:0004510 ! cystadenocarcinoma cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-08T04:58:10Z
 
 [Term]
@@ -32153,7 +32170,7 @@ id: BTO:0004513
 name: Sertoli cell line
 is_a: BTO:0004229 ! testicular cell line
 relationship: develops_from BTO:0001238 ! Sertoli cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-11T09:38:15Z
 
 [Term]
@@ -32162,7 +32179,7 @@ name: Ser-W3 cell
 def: "Rat Sertoli cell line." [PMID:15082077]
 synonym: "SerW3 cell" RELATED []
 is_a: BTO:0004513 ! Sertoli cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-11T09:38:55Z
 
 [Term]
@@ -32171,7 +32188,7 @@ name: SF-3061 cell
 def: "Human meningioma cell line." [PMID:18516297]
 synonym: "SF3061 cell" RELATED []
 is_a: BTO:0004398 ! meningioma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-11T09:43:04Z
 
 [Term]
@@ -32180,7 +32197,7 @@ name: SF-4068 cell
 def: "Human meningioma cell line." [PMID:18516297]
 synonym: "SF4068 cell" RELATED []
 is_a: BTO:0004398 ! meningioma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-11T09:44:12Z
 
 [Term]
@@ -32189,7 +32206,7 @@ name: SF-4433 cell
 def: "Human meningioma cell line." [PMID:18516297]
 synonym: "SF4433 cell" RELATED []
 is_a: BTO:0004398 ! meningioma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-11T09:44:52Z
 
 [Term]
@@ -32198,7 +32215,7 @@ name: uterine gland
 def: "Simple or branched, tubular gland extending into the lamina propria-submucosa, secreting mucus, lipids, glycogen, protein." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 is_a: BTO:0001979 ! mucous gland
 relationship: part_of BTO:0001422 ! uterine endometrium
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-11T10:19:34Z
 
 [Term]
@@ -32206,7 +32223,7 @@ id: BTO:0004519
 name: myometrial cell
 synonym: "uterine smooth muscle cell" RELATED []
 relationship: part_of BTO:0000907 ! myometrium
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-11T10:23:19Z
 
 [Term]
@@ -32220,7 +32237,7 @@ synonym: "T suppressor cell" RELATED []
 synonym: "Treg cell" RELATED []
 synonym: "Ts cell" RELATED []
 is_a: BTO:0000782 ! T-lymphocyte
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-11T10:28:02Z
 
 [Term]
@@ -32231,7 +32248,7 @@ synonym: "TIG 3-20 cell" RELATED []
 synonym: "TIG3-20 cell" RELATED []
 is_a: BTO:0001242 ! fetal cell line
 relationship: develops_from BTO:0006282 ! TIG-3 cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-11T07:57:27Z
 
 [Term]
@@ -32239,7 +32256,7 @@ id: BTO:0004522
 name: Leydig cell line
 is_a: BTO:0004229 ! testicular cell line
 relationship: develops_from BTO:0000755 ! Leydig cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-11T08:07:47Z
 
 [Term]
@@ -32248,7 +32265,7 @@ name: TM-3 cell
 def: "Mouse Leydig cell line." [PMID:15040802]
 synonym: "TM3 cell" RELATED []
 is_a: BTO:0004522 ! Leydig cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-11T08:09:27Z
 
 [Term]
@@ -32258,7 +32275,7 @@ def: "Epithelium covering the embryonic genital ridges and the gonads that devel
 synonym: "surface epithelium" RELATED []
 is_a: BTO:0000416 ! epithelium
 is_a: BTO:0000514 ! germ
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-11T08:34:59Z
 
 [Term]
@@ -32268,7 +32285,7 @@ def: "The layer of loose connective tissue directly under the skin." [Dorlands_M
 synonym: "sub-tegumental tissue" RELATED []
 synonym: "subtegumental tissue" RELATED []
 is_a: BTO:0000421 ! connective tissue
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-11T08:48:01Z
 
 [Term]
@@ -32276,7 +32293,7 @@ id: BTO:0004526
 name: ulcerative colitis disease specific cell type
 def: "Ulcerative colitis is a disease that causes inflammation and sores, called ulcers, in the lining of the rectum and colon." [National_Digestive_Diseases_Information_Clearinghouse:NDDIC]
 relationship: disease_causes_dysfunction_of BTO:0001613 ! colorectum
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-11T09:12:04Z
 
 [Term]
@@ -32284,7 +32301,7 @@ id: BTO:0004527
 name: uterine luminal fluid
 def: "At the time of oestrus the rat uterus accumulates intraluminal fluid. This fluid engorgement occurs in many species, especially in rodents. The fluid is secreted by the endometrium and oviduct and is retained in the uterus by the high degree of muscle tone at the cervix and uterotubal junction." [PMID:3839534]
 is_a: BTO:0003623 ! uterine fluid
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-11T09:20:02Z
 
 [Term]
@@ -32293,7 +32310,7 @@ name: high endothelial venule
 def: "Specialized area of vascular endothelium found in lymphoid organs, which express a variety of cell-adhesion molecules and is involved in lymphocyte extravasation." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 synonym: "HEV cell" RELATED []
 relationship: part_of BTO:0001853 ! vascular endothelium
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-13T05:53:27Z
 
 [Term]
@@ -32302,7 +32319,7 @@ name: PA-23 cell
 def: "Rat rhabdomyosarcoma cell line." [PMID:19039943]
 synonym: "PA23 cell" RELATED []
 is_a: BTO:0002267 ! rhabdomyosarcoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-13T06:03:17Z
 
 [Term]
@@ -32311,7 +32328,7 @@ name: F5 meningioma cell
 def: "Human malignant meningioma cell line." [PMID:7585498]
 synonym: "F5 cell" RELATED []
 is_a: BTO:0004398 ! meningioma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-13T07:55:41Z
 
 [Term]
@@ -32320,7 +32337,7 @@ name: bolting stage
 def: "To flower or produce seeds prematurely or develop a flowering stem from a rosette." [Dictionary:http\://www.thefreedictionary.com/]
 synonym: "boulting stage" RELATED []
 is_a: BTO:0000720 ! plant form
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-15T08:06:12Z
 
 [Term]
@@ -32329,7 +32346,7 @@ name: C-10 cell
 def: "A line of murine alveolar type II lung epithelial cells." [PMID:19171757]
 synonym: "C10 cell" RELATED []
 is_a: BTO:0003213 ! lung epithelium cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T09:50:05Z
 
 [Term]
@@ -32337,7 +32354,7 @@ id: BTO:0004533
 name: respiratory epithelium cell
 synonym: "airway epithelial cell" RELATED []
 relationship: part_of BTO:0000419 ! respiratory epithelium
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T10:11:21Z
 
 [Term]
@@ -32346,7 +32363,7 @@ name: cystic fibrosis disease specific cell type
 def: "Cystic fibrosis affects the exocrine glands and is characterized by the production of abnormal secretions, leading to mucous build-up. This accumulation of mucus can impair the pancreas and, secondarily, the intestine. Mucous build-up in lungs tends progressively to impair respiration." [Medical_Dictionary:http\://www.medterms.com/]
 synonym: "CF disease specific cell type" RELATED []
 relationship: disease_causes_dysfunction_of BTO:0000765 ! exocrine gland
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T10:12:13Z
 
 [Term]
@@ -32354,7 +32371,7 @@ id: BTO:0004535
 name: medullary collecting duct cell
 def: "Medullary collecting ducts are divided into outer and inner segments, the latter reaching more deeply into the medulla. The variable reabsorption of water and, depending on fluid balances and hormonal influences, the reabsorption or secretion of sodium, potassium, hydrogen and bicarbonate ion continues here." [Encyclopedia:http\://encyclopedia.thefreedictionary.com/]
 relationship: part_of BTO:0004536 ! medullary collecting duct
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T10:25:41Z
 
 [Term]
@@ -32362,7 +32379,7 @@ id: BTO:0004536
 name: medullary collecting duct
 def: "Medullary collecting ducts are divided into outer and inner segments, the latter reaching more deeply into the medulla. The variable reabsorption of water and, depending on fluid balances and hormonal influences, the reabsorption or secretion of sodium, potassium, hydrogen and bicarbonate ion continues here." [Encyclopedia:http\://encyclopedia.thefreedictionary.com/]
 relationship: part_of BTO:0000761 ! collecting duct
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T10:27:23Z
 
 [Term]
@@ -32372,7 +32389,7 @@ def: "The cortical collecting ducts receive filtrate from multiple initial colle
 synonym: "CCD cell" RELATED []
 synonym: "kidney cortical collecting duct cell" RELATED []
 relationship: part_of BTO:0002643 ! cortical collecting duct
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T10:29:18Z
 
 [Term]
@@ -32380,7 +32397,7 @@ id: BTO:0004538
 name: initial collecting tubule
 def: "The initial collecting tubule is a segment with a constitution similar as the collecting duct, but before the convergence with other tubules." [Encyclopedia:http\://encyclopedia.thefreedictionary.com/]
 relationship: part_of BTO:0000761 ! collecting duct
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T10:30:33Z
 
 [Term]
@@ -32388,7 +32405,7 @@ id: BTO:0004539
 name: connecting tubule
 def: "With respect to the renal corpuscle, the connecting tubule is the most proximal part of the collecting duct system. It is adjacent to the distal convoluted tubule, the most distal segment of the renal tubule. Connecting tubules from several adjacent nephrons merge to form cortical collecting tubules, and these may join to form cortical collecting ducts. Connecting tubules of some juxtamedullary nephrons may arch upward, forming an arcade. The connecting tubule derives from the metanephric blastema, but the rest of the system derives from the ureteric bud. Because of this, some sources group the connecting tubule as part of the nephron, rather than grouping it with the collecting duct system." [Encyclopedia:http\://encyclopedia.thefreedictionary.com/]
 relationship: part_of BTO:0000761 ! collecting duct
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T10:31:31Z
 
 [Term]
@@ -32397,7 +32414,7 @@ name: papillary duct
 def: "The terminal portions of the medullary collecting ducts are the papillary ducts, which end at the renal papilla and empty into a minor calyx." [Encyclopedia:http\://encyclopedia.thefreedictionary.com/]
 synonym: "duct of Bellini" RELATED []
 relationship: part_of BTO:0004536 ! medullary collecting duct
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T10:33:49Z
 
 [Term]
@@ -32406,7 +32423,7 @@ name: connecting tubule cell
 def: "For the connecting tubules, the specific cell type is the connecting tubule cell." [Encyclopedia:http\://encyclopedia.thefreedictionary.com/]
 synonym: "CNT cell" RELATED []
 relationship: part_of BTO:0004539 ! connecting tubule
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T10:35:13Z
 
 [Term]
@@ -32414,7 +32431,7 @@ id: BTO:0004542
 name: principal cell
 def: "For the collecting ducts, the specific cell type is the principal cell." [Encyclopedia:http\://encyclopedia.thefreedictionary.com/]
 relationship: part_of BTO:0000761 ! collecting duct
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T10:37:37Z
 
 [Term]
@@ -32422,14 +32439,14 @@ id: BTO:0004543
 name: inner medullary collecting duct cell
 def: "For the inner medullary collecting duct, the specific cell type is the inner medullary collecting duct cell." [Encyclopedia:http\://encyclopedia.thefreedictionary.com/]
 relationship: part_of BTO:0004544 ! inner medullary collecting duct
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T10:38:26Z
 
 [Term]
 id: BTO:0004544
 name: inner medullary collecting duct
 relationship: part_of BTO:0004536 ! medullary collecting duct
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T10:38:57Z
 
 [Term]
@@ -32440,7 +32457,7 @@ synonym: "M-1 CCD cell" RELATED []
 synonym: "M-1 cell" RELATED []
 synonym: "M1-CCD cell" RELATED []
 is_a: BTO:0002658 ! collecting duct cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T10:45:22Z
 
 [Term]
@@ -32449,7 +32466,7 @@ name: hypopharyngeal squamous cell carcinoma cell line
 synonym: "HSCC cell" RELATED []
 is_a: BTO:0002024 ! squamous cell carcinoma cell line
 is_a: BTO:0004439 ! hypopharyngeal carcinoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T11:03:49Z
 
 [Term]
@@ -32457,7 +32474,7 @@ id: BTO:0004547
 name: hypopharyngeal squamous cell carcinoma cell
 is_a: BTO:0001289 ! squamous cell carcinoma cell
 relationship: develops_from BTO:0001740 ! hypopharynx
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T11:05:49Z
 
 [Term]
@@ -32466,7 +32483,7 @@ name: deep inguinal lymph node
 def: "One of several small inconstant lymph nodes, proximal, intermediate and distal deep to the fascia lata and medial to the femoral vein; they receive lymph from the deep structures of the lower limb, from the glans penis and from superficial inguinal nodes; efferents pass to the external iliac nodes." [Medical_Dictionary:http\://www.medilexicon.com/]
 synonym: "nodi lymphatici inguinales profundi" RELATED []
 is_a: BTO:0000784 ! lymph node
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T11:24:39Z
 
 [Term]
@@ -32474,7 +32491,7 @@ id: BTO:0004549
 name: superficial inguinal lymph node
 def: "A group of 12-20 lymph nodes that lie in the subcutaneous tissue below the inguinal ligament and along the terminal part of the great saphenous vein; they drain the skin and subcutaneous tissue of the lower abdominal wall, perineum, buttocks, external genitalia, and lower limbs." [Medical_Dictionary:http\://www.medilexicon.com/]
 is_a: BTO:0000784 ! lymph node
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T11:26:02Z
 
 [Term]
@@ -32486,7 +32503,7 @@ synonym: "nodus lymphoideus inguinalis profundi proximalis" RELATED []
 synonym: "Rosenmueller gland" RELATED []
 synonym: "Rosenmueller node" RELATED []
 is_a: BTO:0004548 ! deep inguinal lymph node
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T11:28:36Z
 
 [Term]
@@ -32495,7 +32512,7 @@ name: WT-100 cell
 def: "Human B-lymphoblastoid cell line." [PMID:10716924]
 synonym: "WT100 cell" RELATED []
 is_a: BTO:0002062 ! B-lymphoblastoid cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T12:02:08Z
 
 [Term]
@@ -32504,7 +32521,7 @@ name: Barrett's epithelial cell line
 synonym: "Barrett's esophageal cell line" RELATED []
 is_a: BTO:0002817 ! esophageal cancer cell line
 relationship: develops_from BTO:0003427 ! Barrett's esophagus
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T01:38:45Z
 
 [Term]
@@ -32513,7 +32530,7 @@ name: E-18 rat primary hippocampal neuron
 def: "Primary Rat Hippocampal Cells are live neurons isolated from micro surgically dissected regions of day 18 embryonic Sprague/Dawley rat brain. These cells are prepared fresh each week and shipped in a nutrient rich medium that keeps the cells alive for up to 14 days under refrigeration." [Neuromics:http\://www.neuromics.com/]
 synonym: "E18 rat primary hippocampal neuron" RELATED []
 is_a: BTO:0003036 ! hippocampal cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T07:27:19Z
 
 [Term]
@@ -32525,14 +32542,14 @@ synonym: "parotid duct" RELATED []
 synonym: "stenonianus" RELATED []
 synonym: "Stensen's duct" RELATED []
 relationship: part_of BTO:0001004 ! parotid gland
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T07:32:50Z
 
 [Term]
 id: BTO:0004555
 name: parotid gland duct epithelium
 relationship: part_of BTO:0004554 ! parotid gland duct
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T07:40:01Z
 
 [Term]
@@ -32546,7 +32563,7 @@ synonym: "submaxillar gland duct" RELATED []
 synonym: "submaxillary duct" RELATED []
 synonym: "Wharton's duct" RELATED []
 relationship: part_of BTO:0001316 ! submandibular gland
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T07:42:48Z
 
 [Term]
@@ -32554,7 +32571,7 @@ id: BTO:0004557
 name: submandibular gland duct epithelium
 synonym: "submandibular duct epithelium" RELATED []
 relationship: part_of BTO:0004556 ! submandibular gland duct
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T07:46:11Z
 
 [Term]
@@ -32564,7 +32581,7 @@ def: "The duct associated with sublingual salivary gland. Located on the floor o
 synonym: "Bartholin's duct" RELATED []
 synonym: "sublingual duct" RELATED []
 relationship: part_of BTO:0001315 ! sublingual gland
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T07:54:16Z
 
 [Term]
@@ -32572,7 +32589,7 @@ id: BTO:0004559
 name: sublingual gland duct epithelium
 synonym: "sublingual duct epithelium" RELATED []
 relationship: part_of BTO:0004558 ! sublingual gland duct
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T07:55:18Z
 
 [Term]
@@ -32582,7 +32599,7 @@ def: "Histologically, the thymus can be divided into a central medulla and a per
 synonym: "medulla of thymus" RELATED []
 synonym: "thymus medulla" RELATED []
 relationship: part_of BTO:0001374 ! thymus
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T08:05:49Z
 
 [Term]
@@ -32590,7 +32607,7 @@ id: BTO:0004561
 name: thymic stromal cell
 def: "Cells in the thymus can be divided into thymic stromal cells and cells of hematopoietic origin." [Wikipedia:The_Free_Encyclopedia]
 relationship: part_of BTO:0001374 ! thymus
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T08:07:21Z
 
 [Term]
@@ -32598,7 +32615,7 @@ id: BTO:0004562
 name: thymic cortical epithelial cell
 def: "Thymic stromal cells include thymic cortical epithelial cells, thymic medullary epithelial cells, and dendritic cells." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0004561 ! thymic stromal cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T08:08:09Z
 
 [Term]
@@ -32608,7 +32625,7 @@ def: "Thymic stromal cells include thymic cortical epithelial cells, thymic medu
 synonym: "medullary thymic epithelial cell" RELATED []
 is_a: BTO:0004561 ! thymic stromal cell
 relationship: part_of BTO:0004565 ! thymic medullary epithelium
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T08:08:55Z
 
 [Term]
@@ -32616,7 +32633,7 @@ id: BTO:0004564
 name: thymic dendritic cell
 def: "Thymic stromal cells include thymic cortical epithelial cells, thymic medullary epithelial cells, and dendritic cells." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0004561 ! thymic stromal cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T08:10:37Z
 
 [Term]
@@ -32624,7 +32641,7 @@ id: BTO:0004565
 name: thymic medullary epithelium
 relationship: part_of BTO:0002934 ! thymic cortex
 relationship: part_of BTO:0004560 ! thymic medulla
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T08:11:30Z
 
 [Term]
@@ -32632,7 +32649,7 @@ id: BTO:0004566
 name: Rb-1 cell
 def: "A smooth muscle cell line derived from rabbit aorta." [PMID:2681130]
 is_a: BTO:0001964 ! aorta smooth muscle cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-16T09:40:17Z
 
 [Term]
@@ -32641,7 +32658,7 @@ name: sessile serrated adenoma cell
 def: "In gastroenterology, a sessile serrated adenoma is a premalignant flat or sessile lesions of the colon. SSAs are thought to lead to colorectal cancer through the serrated pathway." [Wikipedia:The_Free_Encyclopedia]
 synonym: "SSA cell" RELATED []
 is_a: BTO:0003633 ! colonic adenoma cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-17T09:15:09Z
 
 [Term]
@@ -32650,7 +32667,7 @@ name: supportive connective tissue
 def: "Classified as supportive connective tissue are bone, osseous tissue, that makes up virtually the entire skeleton in adult vertebrates and cartilage makes up virtually the entire skeleton in chondrichthyes. In most other vertebrates, it is found primarily in joints, where it provides cushioning." [Wikipedia:The_Free_Encyclopedia]
 synonym: "supporting tissue" RELATED []
 is_a: BTO:0000421 ! connective tissue
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-17T09:43:29Z
 
 [Term]
@@ -32658,7 +32675,7 @@ id: BTO:0004569
 name: ovarian fluid
 def: "The ovarian fluid surrounds eggs from female fish." [PMID:3224504]
 relationship: contained_in BTO:0000975 ! ovary
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-17T10:23:59Z
 
 [Term]
@@ -32667,7 +32684,7 @@ name: ulcer tissue
 def: "A lesion of the skin or of a mucous membrane, such as the one lining the stomach or duodenum, that is accompanied by formation of pus and necrosis of surrounding tissue, usually resulting from inflammation or ischemia." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 relationship: develops_from BTO:0000886 ! mucosa
 relationship: develops_from BTO:0001253 ! skin
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-17T10:40:41Z
 
 [Term]
@@ -32675,7 +32692,7 @@ id: BTO:0004571
 name: L3.3 cell
 def: "Human pancreatic cancer cell line." [PMID:18661517]
 is_a: BTO:0000794 ! pancreatic cancer cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-02-17T06:44:56Z
 
 [Term]
@@ -32684,7 +32701,7 @@ name: HEP-G2/2.2.1 cell
 def: "Human hepatocellular carcinoma cell line; derived from Hep-G2. The parental cells were stably transfected at passage 48 with a human cholesterol 7 alpha-hydroxylase CYP7 minigene/Luciferase construct." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 synonym: "HEP G2/2.2.1 cell" RELATED []
 relationship: develops_from BTO:0000599 ! Hep-G2 cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-11T11:03:10Z
 
 [Term]
@@ -32694,7 +32711,7 @@ def: "Human embryonic kidney cell line." [ATCC_American_Cell_Type_Culture_Collec
 synonym: "BOSC 23 cell" RELATED []
 synonym: "BOSC23 cell" RELATED []
 relationship: develops_from BTO:0006328 ! HEK-293T/17 cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-11T11:07:25Z
 
 [Term]
@@ -32702,7 +32719,7 @@ id: BTO:0004574
 name: dermal microvascular endothelial cell
 synonym: "DMEC cell" RELATED []
 is_a: BTO:0003123 ! microvascular endothelial cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-11T11:11:39Z
 
 [Term]
@@ -32712,7 +32729,7 @@ def: "A cancerous tumour of the kidney in children. Wilms is the most common tum
 synonym: "Wilms tumor cell" RELATED []
 synonym: "Wilms tumour cell" RELATED []
 is_a: BTO:0000680 ! kidney cancer cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-11T11:33:42Z
 
 [Term]
@@ -32721,7 +32738,7 @@ name: smooth muscle cell
 def: "Muscle tissue that lacks cross striations, that is made up of elongated spindle-shaped cells having a central nucleus, and that is found in vertebrate visceral structures (as the stomach and bladder) as thin sheets performing functions not subject to conscious control by the mind and in all or most of the musculature of invertebrates other than arthropods." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.m-w.com/cgi-bin/dictionary?book=Dictionary&va=smooth+muscle]
 synonym: "SMC cell" RELATED []
 relationship: part_of BTO:0001260 ! smooth muscle
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-11T12:08:02Z
 
 [Term]
@@ -32731,7 +32748,7 @@ synonym: "aorta vascular smooth muscle cell" RELATED []
 synonym: "aortic vascular smooth muscle cell" RELATED []
 is_a: BTO:0004578 ! vascular smooth muscle cell
 relationship: part_of BTO:0001685 ! aortic smooth muscle
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-11T12:12:09Z
 
 [Term]
@@ -32740,7 +32757,7 @@ name: vascular smooth muscle cell
 def: "Vascular smooth muscle refers to the particular type of smooth muscle found within, and composing the majority of the wall of blood vessels." [Wikipedia:The_Free_Encyclopedia]
 synonym: "VSMC cell" RELATED []
 relationship: part_of BTO:0001431 ! vascular smooth muscle
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-11T12:13:16Z
 
 [Term]
@@ -32750,7 +32767,7 @@ def: "The basic cellular tissue comprising the thyroid gland, organized as folli
 synonym: "parenchyma glandulae thyroideae" RELATED []
 synonym: "thyroid parenchyma" RELATED []
 is_a: BTO:0001379 ! thyroid gland
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-11T12:22:33Z
 
 [Term]
@@ -32758,7 +32775,7 @@ id: BTO:0004580
 name: 862L cell
 def: "Mouse pheochromocytoma cell line." [PMID:17196587]
 is_a: BTO:0000201 ! pheochromocytoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-12T10:32:38Z
 
 [Term]
@@ -32766,7 +32783,7 @@ id: BTO:0004581
 name: 10/9CRC1 cell
 def: "Mouse pheochromocytoma cell line." [PMID:17196587]
 is_a: BTO:0000201 ! pheochromocytoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-12T10:33:48Z
 
 [Term]
@@ -32774,7 +32791,7 @@ id: BTO:0004582
 name: A31N-ts20 cell
 def: "Mouse embryonic fibroblast cell line." [PMID:10848989]
 relationship: develops_from BTO:0000218 ! BALB/3T3 cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-12T10:36:00Z
 
 [Term]
@@ -32782,7 +32799,7 @@ id: BTO:0004583
 name: A-704 cell
 def: "Human kidney adenocarcinoma cell line, established from a 78 years old male." [CLS-Cell_Lines_Service:http\://www.cell-lines-service.de/]
 is_a: BTO:0000383 ! renal cell carcinoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-12T10:38:39Z
 
 [Term]
@@ -32792,7 +32809,7 @@ def: "Acute leukemia distinguished from acute lymphocytic leukemia (ALL) by the 
 synonym: "acute nonlymphocytic leukemia cell" RELATED []
 synonym: "ANLL cell" RELATED []
 is_a: BTO:0001545 ! acute myeloid leukemia cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-12T10:48:40Z
 
 [Term]
@@ -32802,7 +32819,7 @@ def: "A subtype of acute myelogenous leukemia (AML), a cancer of the blood and b
 synonym: "acute progranulocytic leukemia cell" RELATED []
 synonym: "APL cell" RELATED []
 is_a: BTO:0001545 ! acute myeloid leukemia cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-12T10:58:54Z
 
 [Term]
@@ -32810,7 +32827,7 @@ id: BTO:0004586
 name: alevin
 def: "A young fish; especially: a newly hatched salmon when still attached to the yolk sac." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/alevin]
 is_a: BTO:0000284 ! organism form
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-12T11:02:54Z
 
 [Term]
@@ -32818,7 +32835,7 @@ id: BTO:0004587
 name: AT6.1 cell
 def: "Rat prostate carcinoma cell line." [PMID:12644459]
 is_a: BTO:0001033 ! prostate cancer cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-12T11:22:55Z
 
 [Term]
@@ -32826,7 +32843,7 @@ id: BTO:0004588
 name: BHY cell
 def: "Oral squamous cell carcinoma cell line." [PMID:17719389]
 is_a: BTO:0002211 ! oral squamous cell carcinoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-12T11:25:14Z
 
 [Term]
@@ -32834,14 +32851,14 @@ id: BTO:0004589
 name: HN cell
 def: "Oral squamous cell carcinoma cell line." [PMID:17719389]
 is_a: BTO:0002211 ! oral squamous cell carcinoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-12T11:26:34Z
 
 [Term]
 id: BTO:0004590
 name: nasal epithelium cell line
 relationship: develops_from BTO:0000912 ! nasal mucosa
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-12T11:28:38Z
 
 [Term]
@@ -32849,7 +32866,7 @@ id: BTO:0004591
 name: NHEC cell
 def: "Human normal nasal epithelial cell line." [PMID:17719389]
 is_a: BTO:0004590 ! nasal epithelium cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-12T11:29:02Z
 
 [Term]
@@ -32857,7 +32874,7 @@ id: BTO:0004592
 name: bone matrix
 def: "The intercellular substance of bone tissue consisting of collagen fibers, ground substance, and inorganic bone salts." [The_American_Heritage_Medical_Dictionary:2009]
 relationship: part_of BTO:0000140 ! bone
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-12T07:56:37Z
 
 [Term]
@@ -32865,7 +32882,7 @@ id: BTO:0004593
 name: epiblast
 def: "The upper layer of the bilaminar embryonic disc present during the second week of a blastula that gives rise to the ectoderm after gastrulation." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 relationship: part_of BTO:0000494 ! germinal disc
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-12T08:01:59Z
 
 [Term]
@@ -32874,7 +32891,7 @@ name: CWR-22 cell
 def: "Androgen-dependent human prostate cancer cell line." [PMID:20332464]
 synonym: "CWR22 cell" RELATED []
 is_a: BTO:0001033 ! prostate cancer cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-12T08:09:16Z
 
 [Term]
@@ -32885,7 +32902,7 @@ synonym: "D407 cell" RELATED []
 synonym: "RPE D407 cell" RELATED []
 synonym: "RPE-D407 cell" RELATED []
 is_a: BTO:0002334 ! retinal pigment epithelium cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-12T08:16:16Z
 
 [Term]
@@ -32893,7 +32910,7 @@ id: BTO:0004596
 name: garland cell
 def: "The garland cell of Drosophila is a nephrocyte which takes up waste products from the haemolymph." [PMID:2808544]
 is_a: BTO:0004597 ! nephrocyte
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-12T08:45:36Z
 
 [Term]
@@ -32901,7 +32918,7 @@ id: BTO:0004597
 name: nephrocyte
 def: "In most Arthropoda, one of the large phagocytic cells that accumulate waste products." [Encyclopedia.com:http\://www.encyclopedia.com/]
 is_a: BTO:0001044 ! phagocyte
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-12T08:47:45Z
 
 [Term]
@@ -32910,7 +32927,7 @@ name: TE-15 cell
 def: "Human esophageal squamous cell carcinoma cell line." [PMID:19526206]
 synonym: "TE15 cell" RELATED []
 is_a: BTO:0002428 ! esophageal squamous cell carcinoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-12T09:11:19Z
 
 [Term]
@@ -32919,7 +32936,7 @@ name: TE-13 cell
 def: "Human esophageal squamous cell carcinoma cell line." [PMID:19526206]
 synonym: "TE13 cell" RELATED []
 is_a: BTO:0002428 ! esophageal squamous cell carcinoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-12T09:12:03Z
 
 [Term]
@@ -32928,7 +32945,7 @@ name: TE-8 cell
 def: "Human esophageal squamous cell carcinoma cell line." [PMID:19526206]
 synonym: "TE8 cell" RELATED []
 is_a: BTO:0002428 ! esophageal squamous cell carcinoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-12T09:12:36Z
 
 [Term]
@@ -32937,7 +32954,7 @@ name: TE-1 cell
 def: "Human esophageal squamous cell carcinoma cell line." [PMID:19526206]
 synonym: "TE1 cell" RELATED []
 is_a: BTO:0002428 ! esophageal squamous cell carcinoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-12T09:13:04Z
 
 [Term]
@@ -32946,7 +32963,7 @@ name: human aortic endothelial cell
 def: "Human aortic endothelial cell line." [Invitrogen:http\://products.invitrogen.com/]
 synonym: "HAEC cell" RELATED []
 is_a: BTO:0003246 ! aortic endothelial cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-13T09:34:08Z
 
 [Term]
@@ -32954,7 +32971,7 @@ id: BTO:0004603
 name: HBE cell
 def: "Human bronchial epithelial cell line." [PMID:18635526]
 is_a: BTO:0002022 ! bronchial epithelial cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-13T09:36:05Z
 
 [Term]
@@ -32963,7 +32980,7 @@ name: IEC-18 cell
 def: "A nontransformed rat small intestine cell line." [PMID:1500831]
 synonym: "IEC18 cell" RELATED []
 is_a: BTO:0001537 ! small intestine cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-13T09:38:28Z
 
 [Term]
@@ -32990,7 +33007,7 @@ synonym: "MDCK I cell" RELATED []
 synonym: "MDCK.1 cell" RELATED []
 synonym: "MDCK1 cell" RELATED []
 relationship: develops_from BTO:0000837 ! MDCK cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-13T10:57:30Z
 
 [Term]
@@ -33001,7 +33018,7 @@ synonym: "MDCK II cell" RELATED []
 synonym: "MDCK.2 cell" RELATED []
 synonym: "MDCK2 cell" RELATED []
 relationship: develops_from BTO:0000837 ! MDCK cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-13T10:58:41Z
 
 [Term]
@@ -33010,7 +33027,7 @@ name: Henles loop
 def: "The long U-shaped part of the renal tubule, extending through the medulla from the end of the proximal convoluted tubule. It begins with a descending limb comprising the proximal straight tubule and the thin tubule, followed by the ascending limb the distal straight tubule, and ending at the distal convoluted tubule." [Dorlands_Medical_Dictionary:MerckSource]
 synonym: "loop of Henle" RELATED []
 relationship: part_of BTO:0000343 ! renal tubule
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-13T11:09:09Z
 
 [Term]
@@ -33018,14 +33035,14 @@ id: BTO:0004609
 name: TALH cell
 def: "Cultures of rabbit immortalized thick ascending limb of Henles loop." [PMID:9312212]
 is_a: BTO:0004610 ! Henles loop cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-13T11:10:45Z
 
 [Term]
 id: BTO:0004610
 name: Henles loop cell line
 relationship: develops_from BTO:0004608 ! Henles loop
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-13T11:12:13Z
 
 [Term]
@@ -33035,7 +33052,7 @@ def: "Human lung squamous cell carcinoma grade IV. The tumor originated in the l
 synonym: "SW 900 cell" RELATED []
 synonym: "SW900 cell" RELATED []
 is_a: BTO:0002202 ! lung squamous cell carcinoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-13T02:21:22Z
 
 [Term]
@@ -33048,7 +33065,7 @@ synonym: "WM-793 cell" RELATED []
 synonym: "WM793 cell" RELATED []
 synonym: "WM793B cell" RELATED []
 is_a: BTO:0000849 ! melanoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-13T02:25:15Z
 
 [Term]
@@ -33058,7 +33075,7 @@ def: "These cells form sebaceous glands. Sebocytes are epithelial cells that ori
 synonym: "sebaceous cell" RELATED []
 synonym: "sebaceous gland cell" RELATED []
 relationship: part_of BTO:0001980 ! sebaceous gland
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-13T02:31:08Z
 
 [Term]
@@ -33067,14 +33084,14 @@ name: NOSE1 cell
 def: "Normal human ovarian surface epithelial cell line." [PMID:15867372]
 synonym: "NOSE.1 cell" RELATED []
 is_a: BTO:0004482 ! ovarian surface epithelial cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-13T02:47:52Z
 
 [Term]
 id: BTO:0004615
 name: regulatory dendritic cell
 is_a: BTO:0002042 ! dendritic cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-13T06:22:48Z
 
 [Term]
@@ -33087,7 +33104,7 @@ synonym: "tenia semicircularis" RELATED []
 synonym: "terminal stria" RELATED []
 relationship: part_of BTO:0000614 ! hypothalamus
 relationship: part_of BTO:0001042 ! amygdala
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-13T06:25:29Z
 
 [Term]
@@ -33103,7 +33120,7 @@ id: BTO:0004618
 name: T-289 cell
 def: "Human melanoma cell line." [PMID:10661763]
 is_a: BTO:0000849 ! melanoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-13T09:15:06Z
 
 [Term]
@@ -33114,7 +33131,7 @@ synonym: "OCI AML2 cell" RELATED []
 synonym: "OCI-AML-2 cell" RELATED []
 synonym: "OCI/AML-2 cell" RELATED []
 is_a: BTO:0001883 ! acute myeloid leukemia cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-13T09:19:13Z
 
 [Term]
@@ -33125,7 +33142,7 @@ synonym: "OCI AML3 cell" RELATED []
 synonym: "OCI-AML-3 cell" RELATED []
 synonym: "OCI/AML-3 cell" RELATED []
 is_a: BTO:0001883 ! acute myeloid leukemia cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-13T09:21:48Z
 
 [Term]
@@ -33136,7 +33153,7 @@ synonym: "OCI AML5 cell" RELATED []
 synonym: "OCI-AML-5 cell" RELATED []
 synonym: "OCI/AML-5 cell" RELATED []
 is_a: BTO:0001883 ! acute myeloid leukemia cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-13T09:22:50Z
 
 [Term]
@@ -33145,7 +33162,7 @@ name: OCI-M1 cell
 def: "Human acute myeloid leukemia cell line; established from erythroleukemia blasts, AML M6, of a 62-year-old patient following a 7-year chlorambucil treatment for chronic lymphocytic leukemia." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 synonym: "OCI M1 cell" RELATED []
 is_a: BTO:0001883 ! acute myeloid leukemia cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-13T09:24:17Z
 
 [Term]
@@ -33154,7 +33171,7 @@ name: OCI-M2 cell
 def: "Human acute myelocytic leukemia cell line; established in 1984 from the leukemic cells of a 56-year-old patient with erythroleukemia, AML-M6, representing the end stage of a previously identified myelodysplastic syndrome." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 synonym: "OCI M2 cell" RELATED []
 is_a: BTO:0001883 ! acute myeloid leukemia cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-13T09:25:58Z
 
 [Term]
@@ -33162,7 +33179,7 @@ id: BTO:0004624
 name: YN-1 cell
 def: "Human erythroleukemia cell line." [PMID:19187226]
 is_a: BTO:0000846 ! erythroleukemia cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-13T09:30:44Z
 
 [Term]
@@ -33173,7 +33190,7 @@ synonym: "interferon-producing cell" RELATED []
 synonym: "IPC cell" RELATED []
 synonym: "pDC cell" RELATED []
 is_a: BTO:0002042 ! dendritic cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-13T09:37:52Z
 
 [Term]
@@ -33182,7 +33199,7 @@ name: carotid artery endothelium
 synonym: "carotid endothelium" RELATED []
 is_a: BTO:0001853 ! vascular endothelium
 relationship: part_of BTO:0000168 ! carotid artery
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-14T09:16:01Z
 
 [Term]
@@ -33190,7 +33207,7 @@ id: BTO:0004627
 name: carotid artery endothelial cell
 synonym: "carotid endothelial cell" RELATED []
 relationship: part_of BTO:0004626 ! carotid artery endothelium
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-14T09:17:45Z
 
 [Term]
@@ -33198,7 +33215,7 @@ id: BTO:0004628
 name: aortic valve
 def: "One of the four valves in the heart, this valve is situated at exit of the left ventricle of the heart where the aorta begins. The aortic valve lets blood from the left ventricle be pumped up into the aorta but prevents blood once it is in the aorta from returning to the heart." [Medical_Dictionary:http\://www.medterms.com/]
 relationship: part_of BTO:0000135 ! aorta
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-14T09:22:13Z
 
 [Term]
@@ -33206,14 +33223,14 @@ id: BTO:0004629
 name: metaphloem
 def: "The primary phloem that forms after differentiation of the protophloem." [Encyclopedia:http\://encyclopedia.thefreedictionary.com/]
 relationship: develops_from BTO:0000310 ! protophloem
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-14T09:34:23Z
 
 [Term]
 id: BTO:0004630
 name: middle midgut
 relationship: part_of BTO:0000863 ! midgut
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-14T09:45:07Z
 
 [Term]
@@ -33222,14 +33239,14 @@ name: glomerular endothelium
 def: "The glomerular endothelium sits on a very thick glomerular basement membrane." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0000393 ! endothelium
 relationship: part_of BTO:0000530 ! renal glomerulus
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-14T10:48:03Z
 
 [Term]
 id: BTO:0004632
 name: glomerular endothelial cell
 relationship: part_of BTO:0004631 ! glomerular endothelium
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-14T10:53:15Z
 
 [Term]
@@ -33237,7 +33254,7 @@ id: BTO:0004633
 name: invasive breast apocrine carcinoma cell
 synonym: "invasive apocrine carcinoma cell of the breast" RELATED []
 is_a: BTO:0002326 ! breast apocrine carcinoma cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-14T11:11:30Z
 
 [Term]
@@ -33246,7 +33263,7 @@ name: thoracico-abdominal ganglion
 synonym: "thoracic abdominal ganglion" RELATED []
 synonym: "thoracicoabdominal ganglion" RELATED []
 is_a: BTO:0000497 ! ganglion
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-14T11:14:59Z
 
 [Term]
@@ -33255,7 +33272,7 @@ name: 29-13 cell
 def: "Procyclic trypanosome cell line of Trypanosoma brucei." [PMID:12615326]
 synonym: "procyclic 29-13 cell" RELATED []
 is_a: BTO:0004243 ! trypanosomoid cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-14T08:56:40Z
 
 [Term]
@@ -33263,14 +33280,14 @@ id: BTO:0004636
 name: urinary bladder endothelium
 is_a: BTO:0000393 ! endothelium
 is_a: BTO:0001694 ! urinary bladder epithelium
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-14T09:07:52Z
 
 [Term]
 id: BTO:0004637
 name: urinary bladder endothelial cell
 relationship: part_of BTO:0004636 ! urinary bladder endothelium
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-14T09:08:17Z
 
 [Term]
@@ -33279,7 +33296,7 @@ name: peribronchial gland
 def: "There are serous cells in the peribronchial gland of the lung." [PMID:19656456]
 is_a: BTO:0000765 ! exocrine gland
 relationship: part_of BTO:0000763 ! lung
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-15T01:42:26Z
 
 [Term]
@@ -33288,7 +33305,7 @@ name: TT2 ES cell
 def: "Murine embryonic stem cell line; established from an F1 embryo between a C57BL/6 female and a CBA male." [PMID:8250257]
 synonym: "TT2 cell" RELATED []
 is_a: BTO:0001581 ! embryonic stem cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-15T01:54:00Z
 
 [Term]
@@ -33304,7 +33321,7 @@ creation_date: 2013-03-15T12:57:07Z
 id: BTO:0004641
 name: tracheal cell line
 relationship: develops_from BTO:0001388 ! trachea
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-04-16T09:16:55Z
 
 [Term]
@@ -33313,49 +33330,49 @@ name: abductor
 def: "Any muscle used to pull a body part away from the midline of the body. For example, the abductor muscles of the legs spread the legs away from the midline and away from one another. An abductor muscle opposes an adductor muscle." [Medical_Dictionary:http\://www.medterms.com/]
 synonym: "abductor muscle" RELATED []
 is_a: BTO:0001103 ! skeletal muscle
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-05T09:59:46Z
 
 [Term]
 id: BTO:0004643
 name: culture condition:1-naphthoic acid-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-05T10:15:32Z
 
 [Term]
 id: BTO:0004644
 name: culture condition:acenaphthylene-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-05T10:16:10Z
 
 [Term]
 id: BTO:0004645
 name: culture condition:cocaine-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-05T10:16:40Z
 
 [Term]
 id: BTO:0004646
 name: culture condition:phenanthrene-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-05T10:17:08Z
 
 [Term]
 id: BTO:0004647
 name: culture condition:phosphonopyruvate-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-05T10:18:38Z
 
 [Term]
 id: BTO:0004648
 name: culture condition:sucrose-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-05T10:19:36Z
 
 [Term]
@@ -33363,7 +33380,7 @@ id: BTO:0004649
 name: fin
 def: "An external membranous process of an aquatic animal as a fish used in propelling or guiding the body." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/fin]
 relationship: part_of BTO:0001493 ! trunk
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-05T08:09:22Z
 
 [Term]
@@ -33371,7 +33388,7 @@ id: BTO:0004650
 name: dorsal fin
 def: "The unpaired fin located on the back of both bony fish and sharks. It may be single and soft-rayed, as in trout, or double with the anterior dorsal fin supported by fin spines, as in perch. In some species, e.g. eels, the dorsal fin is confluent with the tail fin." [Encyclopedia.com:http\://www.encyclopedia.com/]
 is_a: BTO:0004649 ! fin
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-05T08:09:41Z
 
 [Term]
@@ -33380,7 +33397,7 @@ name: pelvic fin
 def: "One of the pair of fins positioned on the under-side of the body of a fish. Depending on the species, the pelvic fins can be found in a mid-ventral position underneath or just behind the pectoral fins or in front of the pectorals in the throat region." [Encyclopedia.com:http\://www.encyclopedia.com/]
 synonym: "ventral fin" RELATED []
 is_a: BTO:0004649 ! fin
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-05T08:10:01Z
 
 [Term]
@@ -33388,7 +33405,7 @@ id: BTO:0004652
 name: anal fin
 def: "The unpaired fin located on the ventral side of the body of a fish, posterior to the anus. It plays an important role in the swimming movements of sharks and bony fish." [Encyclopedia.com:http\://www.encyclopedia.com/]
 is_a: BTO:0004649 ! fin
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-05T08:10:12Z
 
 [Term]
@@ -33396,7 +33413,7 @@ id: BTO:0004653
 name: pectoral fin
 def: "In fish, one of the pair of fins that are situated one on each side of the fish just behind the gills. Normally they are used for balancing and braking, but in some species, e.g. Exocoetidae, flying fish, the extra-large fins are used for jumping and for gliding over the water surface." [Encyclopedia.com:http\://www.encyclopedia.com/]
 is_a: BTO:0004649 ! fin
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-05T08:10:42Z
 
 [Term]
@@ -33410,7 +33427,7 @@ synonym: "SHEP-21N cell" RELATED []
 synonym: "SHEP21N cell" RELATED []
 synonym: "Tet-21/N cell" RELATED []
 relationship: develops_from BTO:0005397 ! SH-EP cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-05T08:56:34Z
 
 [Term]
@@ -33418,14 +33435,14 @@ id: BTO:0004655
 name: SK-ChA-1 cell
 def: "Human cholangiocarcinoma cell line." [PMID:9331094]
 is_a: BTO:0002932 ! cholangiocarcinoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-05T09:04:17Z
 
 [Term]
 id: BTO:0004656
 name: follicular lymphoma cell
 is_a: BTO:0001690 ! B-cell lymphoma cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-05T09:07:48Z
 
 [Term]
@@ -33434,7 +33451,7 @@ name: premonocyte
 def: "An immature monocyte not normally present in the blood." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 synonym: "promonocyte" RELATED []
 is_a: BTO:0000876 ! monocyte
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-05T09:18:34Z
 
 [Term]
@@ -33442,7 +33459,7 @@ id: BTO:0004658
 name: imaginal disc
 def: "A group of undifferentiated cells in an insect larva that develops into a specific adult structure." [Encyclopedia.com:http\://www.encyclopedia.com/]
 is_a: BTO:0000707 ! larva
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-05T09:21:40Z
 
 [Term]
@@ -33451,7 +33468,7 @@ name: exoskeleton
 def: "Exoskeleton or shell, including those of mollusks, turtles, insects and crustaceans." [Wikipedia:The_Free_Encyclopedia]
 synonym: "shell" RELATED []
 is_a: BTO:0000634 ! integument
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-05T09:24:54Z
 
 [Term]
@@ -33459,7 +33476,7 @@ id: BTO:0004660
 name: human amniotic epithelial cell
 synonym: "HAEC cell" RELATED []
 is_a: BTO:0001373 ! amnion epithelial cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-10T09:54:49Z
 
 [Term]
@@ -33467,21 +33484,21 @@ id: BTO:0004661
 name: iliac artery endothelium
 is_a: BTO:0001853 ! vascular endothelium
 relationship: part_of BTO:0004665 ! iliac artery
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-10T09:58:05Z
 
 [Term]
 id: BTO:0004662
 name: iliac artery endothelial cell
 relationship: part_of BTO:0004661 ! iliac artery endothelium
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-10T09:58:27Z
 
 [Term]
 id: BTO:0004663
 name: iliac artery endothelial cell line
 relationship: develops_from BTO:0004662 ! iliac artery endothelial cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-10T09:58:59Z
 
 [Term]
@@ -33490,7 +33507,7 @@ name: human iliac artery endothelial cell
 def: "Human arterial endothelial cells, HAECs, are isolated from adult human iliac arteries of transplant donors by mechanically removing the endothelial layer and are cultured." [PMID:18523127]
 synonym: "HAEC cell" RELATED []
 is_a: BTO:0004663 ! iliac artery endothelial cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-10T09:59:18Z
 
 [Term]
@@ -33499,7 +33516,7 @@ name: iliac artery
 def: "Either of the large arteries supplying blood to the lower trunk and hind limbs and arising by bifurcation of the aorta which in humans occurs at the level of the fourth lumbar vertebra to form one vessel for each side of the body." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/iliac_artery]
 synonym: "common iliac artery" RELATED []
 is_a: BTO:0000573 ! artery
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-10T10:05:14Z
 
 [Term]
@@ -33507,7 +33524,7 @@ id: BTO:0004666
 name: external iliac artery
 def: "The outer branch of the common iliac artery on either side of the body that passes beneath the inguinal ligament to become the femoral artery." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/iliac_artery]
 relationship: part_of BTO:0004665 ! iliac artery
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-10T10:06:54Z
 
 [Term]
@@ -33516,7 +33533,7 @@ name: internal iliac artery
 def: "The inner branch of the common iliac artery on either side of the body that soon breaks into several branches and supplies blood chiefly to the pelvic and gluteal areas." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/iliac_artery]
 synonym: "hypogastric artery" RELATED []
 relationship: part_of BTO:0004665 ! iliac artery
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-10T10:07:40Z
 
 [Term]
@@ -33524,7 +33541,7 @@ id: BTO:0004668
 name: hand
 def: "1. The terminal part of the vertebrate forelimb when modified, as in humans, as a grasping organ. 2. A part serving the function of or resembling a hand as the hind foot of an ape or the chela of a crustacean." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/hand]
 relationship: part_of BTO:0001435 ! arm
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-10T12:30:02Z
 
 [Term]
@@ -33534,7 +33551,7 @@ def: "Any of the five terminating members of the hand, a digit of the forelimb."
 synonym: "digit" RELATED []
 synonym: "forelimb digit" RELATED []
 relationship: part_of BTO:0004668 ! hand
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-10T12:30:15Z
 
 [Term]
@@ -33543,7 +33560,7 @@ name: interdigit
 def: "The area of the hand or foot lying between adjacent digits." [The_American_Heritage_Dictionary_of_the_English_Language:Fourth_Edition._2000.]
 relationship: part_of BTO:0000476 ! foot
 relationship: part_of BTO:0004668 ! hand
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-10T12:31:50Z
 
 [Term]
@@ -33552,7 +33569,7 @@ name: hair medulla
 def: "The medulla is the inner most layer of the hair shaft." [Wikipedia:The_Free_Encyclopedia]
 synonym: "medulla of hair shaft" RELATED []
 relationship: part_of BTO:0004672 ! hair shaft
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-10T12:48:26Z
 
 [Term]
@@ -33561,7 +33578,7 @@ name: hair shaft
 def: "The non-growing portion of a hair which protrudes from the skin, i.e., from the follicle." [Biology-Online_Dictionary:http\://www.biology-online.org/dictionary/]
 synonym: "scapus pili" RELATED []
 relationship: part_of BTO:0001501 ! hair
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-10T12:51:05Z
 
 [Term]
@@ -33571,7 +33588,7 @@ def: "The artery in vertebrate embryos that transports blood from the aortic arc
 synonym: "dorsal aortic root" RELATED []
 is_a: BTO:0000135 ! aorta
 relationship: part_of BTO:0000379 ! embryo
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-12T10:55:29Z
 
 [Term]
@@ -33580,7 +33597,7 @@ name: ventral aorta
 def: "The artery in vertebrate embryos that carries blood from the ventricle of the heart to the aortic arches. In adult fish it branches into afferent branchial arteries supplying the gills. In adult tetrapods it is represented by the ascending part of the aorta." [Encyclopedia.com:http\://www.encyclopedia.com/]
 is_a: BTO:0000135 ! aorta
 relationship: part_of BTO:0000379 ! embryo
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-12T10:57:59Z
 
 [Term]
@@ -33589,7 +33606,7 @@ name: regio occipitalis capitis
 def: "The surface region of the head corresponding to the outlines of the occipital bone." [Biology-Online_Dictionary:http\://www.biology-online.org/dictionary/]
 synonym: "occipital region of head" RELATED []
 relationship: part_of BTO:0000282 ! head
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-12T11:14:56Z
 
 [Term]
@@ -33599,7 +33616,7 @@ def: "Either of two large bundles of nerve fibers passing from the pons forward 
 is_a: BTO:0002191 ! fibre tract
 relationship: part_of BTO:0000138 ! midbrain
 relationship: part_of BTO:0000231 ! cerebral hemisphere
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-12T01:08:56Z
 
 [Term]
@@ -33609,7 +33626,7 @@ def: "The large bundle of nerve fiber tracts forming the anterior part of the ce
 synonym: "base of cerebral peduncle" RELATED []
 synonym: "crus cerebri" RELATED []
 relationship: part_of BTO:0004676 ! cerebral peduncle
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-12T01:09:11Z
 
 [Term]
@@ -33618,7 +33635,7 @@ name: regio frontalis capitis
 def: "The surface region of the head corresponding to the outlines of the frontal bone." [Medical_Dictionary:http\://www.medilexicon.com/]
 synonym: "frontal region of head" RELATED []
 relationship: part_of BTO:0000282 ! head
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-12T01:36:14Z
 
 [Term]
@@ -33627,7 +33644,7 @@ name: capillary pericyte
 def: "A cell with several slender processes that embraces the capillary wall in amphibia." [Biology-Online_Dictionary:http\://www.biology-online.org/dictionary/]
 synonym: "Rouget cell" RELATED []
 is_a: BTO:0002441 ! pericyte
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-07-22T10:17:53Z
 
 [Term]
@@ -33637,7 +33654,7 @@ def: "The deepest layer, as of the epidermis or the endometrium. In the epidermi
 synonym: "basal layer" RELATED []
 relationship: part_of BTO:0000404 ! epidermis
 relationship: part_of BTO:0001422 ! uterine endometrium
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-12T02:03:17Z
 
 [Term]
@@ -33645,7 +33662,7 @@ id: BTO:0004681
 name: bursa copulatrix
 def: "A thin fan or bell-shaped expansion of the cuticle of the tail of many male nematode worms that functions as a copulatory structure." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/bursa_copulatrix]
 is_a: BTO:0003096 ! internal male genital organ
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-14T09:10:27Z
 
 [Term]
@@ -33653,7 +33670,7 @@ id: BTO:0004682
 name: gential atrium
 def: "A common chamber receiving openings of male, female, and accessory organs." [Encyclopedia:http\://encyclopedia.thefreedictionary.com/]
 relationship: part_of BTO:0000081 ! reproductive system
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-14T09:14:42Z
 
 [Term]
@@ -33661,7 +33678,7 @@ id: BTO:0004683
 name: genital chamber
 def: "A copulatory invagination. In females, sometimes forms a tubular vagina that is often developed to form a bursa copulatrix. In males, a ventral invagination containing the phallic organs." [Online_Dictionary_of_Invertebrate_Zoology:http\://digitalcommons.unl.edu/cgi/viewcontent.cgi?article=1017&context=onlinedictinvertzoology]
 relationship: part_of BTO:0000081 ! reproductive system
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-14T09:18:26Z
 
 [Term]
@@ -33670,7 +33687,7 @@ name: genital pore
 def: "A small opening on the side of the head in some gastropods through which the penis is protruded." [Encyclopedia:http\://encyclopedia.thefreedictionary.com/]
 synonym: "genital orifice" RELATED []
 relationship: part_of BTO:0000081 ! reproductive system
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-14T09:29:04Z
 
 [Term]
@@ -33679,7 +33696,7 @@ name: bony labyrinth
 def: "The bony part of the internal ear." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 relationship: develops_from BTO:0005981 ! auditory capsule
 relationship: part_of BTO:0000630 ! inner ear
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-14T09:38:49Z
 
 [Term]
@@ -33687,7 +33704,7 @@ id: BTO:0004686
 name: cochlear labyrinth
 def: "The part of the membranous labyrinth that includes the perilymphatic space and the cochlear duct." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 relationship: part_of BTO:0000267 ! cochlea
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-14T09:40:05Z
 
 [Term]
@@ -33695,7 +33712,7 @@ id: BTO:0004687
 name: orbit
 def: "The bony socket of the eye." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/orbit]
 relationship: part_of BTO:0000282 ! head
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-14T09:56:53Z
 
 [Term]
@@ -33705,7 +33722,7 @@ def: "The region about the orbit." [Medical_Dictionary:http\://www.medilexicon.c
 synonym: "orbital part of face" RELATED []
 synonym: "orbital region" RELATED []
 relationship: part_of BTO:0000282 ! head
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-14T09:57:50Z
 
 [Term]
@@ -33713,7 +33730,7 @@ id: BTO:0004689
 name: external gill
 def: "External gills are the gills of an animal, most typically an amphibian, that are exposed to the environment, rather than set inside the pharynx and covered by gill slits, as they are in most fishes." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0000518 ! gill
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-14T10:12:08Z
 
 [Term]
@@ -33721,7 +33738,7 @@ id: BTO:0004690
 name: arterial system
 def: "The arterial system is the higher-pressure portion of the circulatory system." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0001085 ! vascular system
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-14T10:16:02Z
 
 [Term]
@@ -33737,7 +33754,7 @@ synonym: "minor hippocampus" RELATED []
 synonym: "Morand spur" RELATED []
 synonym: "unguis avis" RELATED []
 relationship: part_of BTO:0000601 ! hippocampus
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-14T10:20:59Z
 
 [Term]
@@ -33745,7 +33762,7 @@ id: BTO:0004692
 name: venous system
 def: "A system of interconnected blood vessels that returns blood to the heart from the tissue and capillary bed through progressively larger vessels." [Answers.com:http\://www.answers.com/]
 is_a: BTO:0001085 ! vascular system
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-14T10:46:00Z
 
 [Term]
@@ -33754,7 +33771,7 @@ name: regio parietalis capitis
 def: "The surface region of the head corresponding to the outlines of the underlying parietal bone." [Mondofacto_Dictionary:http\://www.mondofacto.com/facts/dictionary?]
 synonym: "parietal region" RELATED []
 relationship: part_of BTO:0000282 ! head
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-14T11:12:44Z
 
 [Term]
@@ -33762,7 +33779,7 @@ id: BTO:0004694
 name: rectal sac
 def: "The enlarged anterior part of the rectum, sometimes produced into a large rectal caecum." [Dictionary_of_entomology\,_plant_pathology_and_nematology:Singh\,_Srivastava]
 relationship: part_of BTO:0001158 ! rectum
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-14T11:49:59Z
 
 [Term]
@@ -33770,7 +33787,7 @@ id: BTO:0004695
 name: aortic root
 def: "The part of the aorta attached to the atrioventricular fibrous rings and myocardium." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 relationship: part_of BTO:0000135 ! aorta
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-14T01:42:40Z
 
 [Term]
@@ -33778,7 +33795,7 @@ id: BTO:0004696
 name: external carotid artery
 def: "In human anatomy, the external carotid artery is a major artery of the head and neck. It arises from the common carotid artery when it bifurcates into the external and internal carotid artery." [Wikipedia:The_Free_Encyclopedia]
 relationship: part_of BTO:0000168 ! carotid artery
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-14T01:56:27Z
 
 [Term]
@@ -33786,7 +33803,7 @@ id: BTO:0004697
 name: internal carotid artery
 def: "In human anatomy, the internal carotid artery is a major artery of the head and neck that helps supply blood to the brain." [Wikipedia:The_Free_Encyclopedia]
 relationship: part_of BTO:0000168 ! carotid artery
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-14T01:57:21Z
 
 [Term]
@@ -33796,21 +33813,21 @@ def: "The region of the face including the lips and mouth." [Biology-Online_Dict
 synonym: "oral part of face" RELATED []
 synonym: "oral region" RELATED []
 relationship: part_of BTO:0000282 ! head
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-14T02:12:33Z
 
 [Term]
 id: BTO:0004699
 name: posterior pharynx
 relationship: part_of BTO:0001049 ! pharynx
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-16T09:08:26Z
 
 [Term]
 id: BTO:0004700
 name: anterior pharynx
 relationship: part_of BTO:0001049 ! pharynx
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-16T09:08:43Z
 
 [Term]
@@ -33819,7 +33836,7 @@ name: dorsal striatum
 def: "Those portions of the caudate nucleus and especially the putamen located generally superior to a plane representing the anterior commissure; also called the dorsal basal ganglia; may function in motor activities with cognitive origins." [Medical_Dictionary:http\://www.medilexicon.com/]
 synonym: "striatum dorsale" RELATED []
 relationship: part_of BTO:0000418 ! neostriatum
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-16T10:03:42Z
 
 [Term]
@@ -33828,7 +33845,7 @@ name: ventral striatum
 def: "Those portions of the striatum located generally inferior to a plane representing the anterior commissure; includes the nucleus accumbens and some nuclei of the olfactory tubercle; may function in motor activities with emotional or motivational origins." [Medical_Dictionary:http\://www.medilexicon.com/]
 synonym: "striatum ventrale" RELATED []
 relationship: part_of BTO:0000418 ! neostriatum
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-16T10:04:52Z
 
 [Term]
@@ -33841,7 +33858,7 @@ synonym: "primary visual cortex" RELATED []
 synonym: "V1" RELATED []
 synonym: "visual area V1" RELATED []
 relationship: part_of BTO:0001857 ! visual cortex
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-17T10:25:17Z
 
 [Term]
@@ -33850,7 +33867,7 @@ name: extrastriate cortex
 def: "The term visual cortex refers to the primary visual cortex and extrastriate visual cortical areas such as V2, V3, V4, and V5. The extrastriate cortical areas consist of Brodmann area 18 and Brodmann area 19. There is a visual cortex for each hemisphere of the brain. The left hemisphere visual cortex receives signals from the right visual field and the right visual cortex from the left visual field." [Wikipedia:The_Free_Encyclopedia]
 synonym: "extrastriate cortical area" RELATED []
 relationship: part_of BTO:0001857 ! visual cortex
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-17T10:27:38Z
 
 [Term]
@@ -33858,7 +33875,7 @@ id: BTO:0004705
 name: connecting stalk
 def: "A bridge of mesoderm connecting the caudal end of the young embryo with the trophoblastic tissues; the precursor of the umbilical cord." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 is_a: BTO:0000839 ! mesoderm
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-17T10:50:01Z
 
 [Term]
@@ -33868,7 +33885,7 @@ def: "A hinge joint formed by the articulating of the tibia and the fibula with 
 synonym: "mortise joint" RELATED []
 synonym: "talocrural joint" RELATED []
 is_a: BTO:0004707 ! hinge joint
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-17T11:00:31Z
 
 [Term]
@@ -33877,7 +33894,7 @@ name: hinge joint
 def: "A joint that allows motion around an axis." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 synonym: "ginglymus" RELATED []
 is_a: BTO:0001686 ! joint
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-17T11:01:45Z
 
 [Term]
@@ -33885,7 +33902,7 @@ id: BTO:0004708
 name: thyroid follicle
 def: "Discrete, cystlike units of the thyroid gland that are lined with cuboidal epithelium and are filled with a colloid substance, about 30 to each lobule." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 relationship: part_of BTO:0001379 ! thyroid gland
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-17T11:10:03Z
 
 [Term]
@@ -33893,7 +33910,7 @@ id: BTO:0004709
 name: thyroid primordium
 def: "In embryology, organ or tissue in its earliest recognizable stage of development. As, for example, the thyroid primordium." [Medical_Dictionary:http\://www.medterms.com/]
 is_a: BTO:0001886 ! primordium
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-17T11:12:04Z
 
 [Term]
@@ -33904,7 +33921,7 @@ synonym: "inner layer of eyeball" RELATED []
 synonym: "internal layer of eyeball" RELATED []
 synonym: "nervous tunic of eyeball" RELATED []
 is_a: BTO:0001175 ! retina
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-18T10:20:20Z
 
 [Term]
@@ -33913,7 +33930,7 @@ name: head capsule
 def: "The insect's head is sometimes referred to as the head-capsule, and is the insect's feeding and sensory centre. It supports the eyes, antennae and jaws of the insect." [The_Insect_Head:http\://www.earthlife.net/insects/anat-head.html]
 synonym: "Kopfkapsel" RELATED GE []
 is_a: BTO:0000282 ! head
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-18T10:35:50Z
 
 [Term]
@@ -33923,7 +33940,7 @@ def: "Parathyroid hormone is secreted from cells of the parathyroid glands and f
 synonym: "parathyroid cell" RELATED []
 synonym: "parathyroid gland cell" RELATED []
 relationship: part_of BTO:0000997 ! parathyroid gland
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-18T10:41:04Z
 
 [Term]
@@ -33932,7 +33949,7 @@ name: larval ventral ganglion
 def: "Abdominal neuromere of the larva. The larval ventral ganglion is less complex than the brain, consists of a smaller number of neurons and shows in general a homomeric composition. Despite its reduced complexity, the larval ventral ganglion possesses peptidergic interneurons as well as neurosecretory cells producing peptide hormones, and receives sensory inputs of different modalities." [PMID:17668072]
 is_a: BTO:0000497 ! ganglion
 relationship: part_of BTO:0000707 ! larva
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-18T10:45:26Z
 
 [Term]
@@ -33942,7 +33959,7 @@ def: "Palatine tonsils are the tonsils that can be seen on the left and right si
 synonym: "faucial tonsil" RELATED []
 synonym: "Gaumenmandel" RELATED GE []
 is_a: BTO:0001387 ! tonsil
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-18T10:57:35Z
 
 [Term]
@@ -33951,7 +33968,7 @@ name: nasopharyngeal tonsil
 def: "The human palatine tonsils and the nasopharyngeal tonsil are lymphoepithelial tissues located in strategic areas of the oropharynx and nasopharynx." [Wikipedia:The_Free_Encyclopedia]
 synonym: "Nasenrachenmandel" RELATED GE []
 is_a: BTO:0001387 ! tonsil
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-18T10:57:52Z
 
 [Term]
@@ -33959,7 +33976,7 @@ id: BTO:0004716
 name: null cell
 def: "A null cell is a large granular lymphocyte without surface markers or membrane-associated proteins from B lymphocytes or T lymphocytes. Members of null cells are natural killer cells, antigen dependent cytotoxic cells and the lymphokine activated killer cells." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0000775 ! lymphocyte
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-18T11:33:17Z
 
 [Term]
@@ -33967,7 +33984,7 @@ id: BTO:0004717
 name: large granular lymphocyte
 def: "A type of white blood cell that contains granules with enzymes that can kill tumor cells or microbial cells." [Dictionary_of_Cancer_Terms:http\://www.cancer.gov/]
 is_a: BTO:0000775 ! lymphocyte
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-18T11:40:56Z
 
 [Term]
@@ -33979,7 +33996,7 @@ synonym: "lobe of mammary gland" RELATED []
 synonym: "lobi glandulae mammariae" RELATED []
 synonym: "lobus glandulae mammariae" RELATED []
 relationship: part_of BTO:0000817 ! mammary gland
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-18T11:46:47Z
 
 [Term]
@@ -33991,7 +34008,7 @@ synonym: "excretory canal" RELATED []
 synonym: "excretory cell" RELATED []
 is_a: BTO:0000431 ! excretory gland
 relationship: part_of BTO:0006338 ! excretory system
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-05-18T12:40:54Z
 
 [Term]
@@ -33999,7 +34016,7 @@ id: BTO:0004720
 name: mural cell
 def: "A nonendothelial cell enclosed within the basement membrane of retinal capillaries." [Mondofacto_Dictionary:http\://www.mondofacto.com/facts/dictionary?]
 relationship: part_of BTO:0001175 ! retina
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-07-22T10:21:53Z
 
 [Term]
@@ -34008,7 +34025,7 @@ name: myeloid dendritic cell
 def: "The most common division of dendritic cells is myeloid versus plasmacytoid. The myeloid dendritic cells are developed from myeloid precursors and are most similar to monocytes. They are made up of at least two subsets: 1. the more common mDC-1, which is a major stimulator of T cells and 2. the extremely rare mDC-2, which may have a function in fighting wound infection. They secrete IL-12." [Answers.com:http\://www.answers.com/]
 synonym: "mDC cell" RELATED []
 is_a: BTO:0002042 ! dendritic cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-07-23T09:04:22Z
 
 [Term]
@@ -34022,7 +34039,7 @@ synonym: "plasmacytoid T cell" RELATED []
 synonym: "plasmacytoid T-cell" RELATED []
 synonym: "T-associated plasma cell" RELATED []
 is_a: BTO:0004625 ! plasmacytoid dendritic cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-07-23T09:10:58Z
 
 [Term]
@@ -34030,7 +34047,7 @@ id: BTO:0004723
 name: lymphoid dendritic cell
 def: "Dendritic cells that develop from lymphoid precursors." [COPE_Cytokines_&_Cells_Online_Pathfinder_Encyclopaedia:http\://www.copewithcytokines.de/cope.cgi]
 is_a: BTO:0002042 ! dendritic cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-07-23T09:22:05Z
 
 [Term]
@@ -34038,7 +34055,7 @@ id: BTO:0004724
 name: animal cap
 def: "In Xenopus embryos the animal cap, which is the area around the animal pole of the blastula, is destined to form the ectoderm during normal development. However, these cells retain pluripotentiality and upon exposure to specific inducers, the animal cap can differentiate into neural, mesodermal, and endodermal tissues. In this sense, the cells of the animal cap are equivalent to mammalian embryonic stem cells." [PMID:19382122]
 relationship: part_of BTO:0000379 ! embryo
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-08-20T08:11:36Z
 
 [Term]
@@ -34046,7 +34063,7 @@ id: BTO:0004725
 name: embryonic fibroblast
 is_a: BTO:0000452 ! fibroblast
 relationship: part_of BTO:0000379 ! embryo
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-08-20T08:25:19Z
 
 [Term]
@@ -34054,7 +34071,7 @@ id: BTO:0004726
 name: embryonic brain
 is_a: BTO:0000142 ! brain
 relationship: part_of BTO:0000379 ! embryo
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-08-20T08:29:57Z
 
 [Term]
@@ -34062,7 +34079,7 @@ id: BTO:0004727
 name: larval brain
 is_a: BTO:0000142 ! brain
 relationship: part_of BTO:0000707 ! larva
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-08-20T08:44:39Z
 
 [Term]
@@ -34072,7 +34089,7 @@ synonym: "rheumatoid arthritic synovial fluid" RELATED []
 synonym: "rheumatoid arthritis synovial fluid" RELATED []
 relationship: develops_from BTO:0001339 ! synovia
 relationship: part_of BTO:0003702 ! rheumatoid arthritis disease specific synovial tissue
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-08-20T08:48:14Z
 
 [Term]
@@ -34082,7 +34099,7 @@ def: "Peripheral blood lymphocytes are mature lymphocytes that circulate in the 
 synonym: "PBL cell" RELATED []
 is_a: BTO:0000775 ! lymphocyte
 is_a: BTO:0001025 ! peripheral blood mononuclear cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-08-20T09:27:43Z
 
 [Term]
@@ -34090,7 +34107,7 @@ id: BTO:0004730
 name: myeloid progenitor cell
 def: "One of the two stem cells derived from hematopoietic stem cells, the other being the lymphoid progenitor cell. Derived from these myeloid progenitor cells are the erythroid progenitor cells and the myeloid cells." [Medical_Dictionary_Online:http\://www.online-medical-dictionary.org/]
 relationship: develops_from BTO:0000725 ! hematopoietic stem cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-08-20T09:34:28Z
 
 [Term]
@@ -34098,7 +34115,7 @@ id: BTO:0004731
 name: lymphoid progenitor cell
 def: "One of the two stem cells derived from hematopoietic stem cells, the other being the myeloid progenitor cell. Derived from these myeloid progenitor cells are the erythroid progenitor cells and the myeloid cells." [Medical_Dictionary_Online:http\://www.online-medical-dictionary.org/]
 relationship: develops_from BTO:0000725 ! hematopoietic stem cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-08-20T09:36:51Z
 
 [Term]
@@ -34111,7 +34128,7 @@ synonym: "bone marrow macrophage" RELATED []
 synonym: "bone marrow-derived monocyte-macrophage cell" RELATED []
 synonym: "primary bone marrow-derived macrophage" RELATED []
 is_a: BTO:0000801 ! macrophage
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-08-20T09:43:18Z
 
 [Term]
@@ -34122,7 +34139,7 @@ synonym: "gravid" RELATED []
 synonym: "pregnant" RELATED []
 synonym: "pregnant adult" RELATED []
 is_a: BTO:0001043 ! adult
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-08-20T10:00:52Z
 
 [Term]
@@ -34130,7 +34147,7 @@ id: BTO:0004734
 name: HBL-100 cell
 def: "Human mammary gland breast carcinoma cell line, established from a 27 years old caucasian female." [CLS-Cell_Lines_Service:http\://www.cell-lines-service.de/]
 is_a: BTO:0004086 ! mammary gland tumor cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-28T05:13:46Z
 
 [Term]
@@ -34138,7 +34155,7 @@ id: BTO:0004735
 name: brainstem glioma cell
 def: "This primary brain tumour occurs in the pons or the medulla. They account for approximately 15% of brain tumours in children. Symptoms include double vision, facial weakness, vomiting and difficulty walking. Surgery is difficult due to location so radiation therapy and chemotherapy are used. Overall survival is 20 to 30%." [Mondofacto_Dictionary:http\://www.mondofacto.com/facts/dictionary?]
 is_a: BTO:0001573 ! brain cancer cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-29T08:43:21Z
 
 [Term]
@@ -34147,7 +34164,7 @@ name: B-CPAP cell
 def: "Human papillary thyroid carcinoma derived cell line." [PMID:15172756]
 synonym: "BCPAP cell" RELATED []
 is_a: BTO:0003210 ! papillary thyroid cancer cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-29T08:47:36Z
 
 [Term]
@@ -34156,7 +34173,7 @@ name: AU-565 cell
 def: "The AU565 cell line was derived from a pleural effusion of a patient with breast adenocarcinoma. This cell line was established from the same patient as SK-BR-3. The patient, a White, Caucasian female, age 43, blood type A+, had been treated with radiation, steroids, cytoxan and 5-fluorouracil." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 synonym: "AU565 cell" RELATED []
 is_a: BTO:0001912 ! breast adenocarcinoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-29T08:51:37Z
 
 [Term]
@@ -34167,7 +34184,7 @@ synonym: "CF-PAC-1 cell" RELATED []
 synonym: "CFPAC cell" RELATED []
 synonym: "CFPAC1 cell" RELATED []
 is_a: BTO:0003883 ! pancreatic ductal adenocarcinoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-29T08:55:53Z
 
 [Term]
@@ -34177,7 +34194,7 @@ def: "Papillary thyroid cancer cell line." [PMID:8888804]
 synonym: "CGTH W-3 cell" RELATED []
 synonym: "CGTH-W-3 cell" RELATED []
 is_a: BTO:0003210 ! papillary thyroid cancer cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-29T09:03:14Z
 
 [Term]
@@ -34187,7 +34204,7 @@ def: "Follicular thyroid cancer cell line." [PMID:8888804]
 synonym: "CGTH W-1 cell" RELATED []
 synonym: "CGTH-W-1 cell" RELATED []
 is_a: BTO:0003874 ! follicular thyroid cancer cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-29T09:04:40Z
 
 [Term]
@@ -34197,7 +34214,7 @@ def: "Follicular thyroid cancer cell line." [PMID:8888804]
 synonym: "CGTH W-2 cell" RELATED []
 synonym: "CGTH-W-2 cell" RELATED []
 is_a: BTO:0003874 ! follicular thyroid cancer cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-29T09:05:26Z
 
 [Term]
@@ -34207,7 +34224,7 @@ def: "Human colon cancer cell line." [PMID:20512578]
 comment: This term is a misspelling in this reference. The right one is HCT-15 cell. Made obsolete.
 synonym: "HCT115 cell" RELATED []
 is_obsolete: true
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-29T09:27:30Z
 
 [Term]
@@ -34217,7 +34234,7 @@ def: "Human colon carcinoma cell line." [Ebony_Ayres:Manipulation_of_Iron_Nanopa
 comment: Made obsolete. Synonym of HCT-116 cell.
 synonym: "HCT166 cell" RELATED []
 is_obsolete: true
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-29T09:30:58Z
 
 [Term]
@@ -34225,7 +34242,7 @@ id: BTO:0004744
 name: hair cell
 def: "Hair cells are the sensory receptors of both the auditory system and the vestibular system in all vertebrates. In mammals, the auditory hair cells are located within the organ of Corti on a thin basilar membrane in the cochlea of the inner ear." [Wikipedia:The_Free_Encyclopedia]
 relationship: part_of BTO:0001691 ! spiral organ
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-29T09:36:28Z
 
 [Term]
@@ -34233,7 +34250,7 @@ id: BTO:0004745
 name: INA-6 cell
 def: "A human myeloma cell line established from patient with IgG-kappa plasma cell leukemia ." [COPE_Cytokines_&_Cells_Online_Pathfinder_Encyclopaedia:http\://www.copewithcytokines.de/cope.cgi]
 is_a: BTO:0000899 ! myeloma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-29T09:39:02Z
 
 [Term]
@@ -34241,7 +34258,7 @@ id: BTO:0004746
 name: cecum cancer cell line
 is_a: BTO:0001621 ! intestinal cancer cell line
 relationship: develops_from BTO:0000166 ! cecum
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-29T09:41:22Z
 
 [Term]
@@ -34249,7 +34266,7 @@ id: BTO:0004747
 name: NCI-H716 cell
 def: "A cell line derived from a poorly differentiated adenocarcinoma of the caecum." [PMID:1359704]
 is_a: BTO:0004746 ! cecum cancer cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-29T09:43:11Z
 
 [Term]
@@ -34257,7 +34274,7 @@ id: BTO:0004748
 name: metula
 def: "A sterile cell below the phialides of some Aspergillus and Penicillium species." [Glossary_of_Mycological_Terms:http\://www.mycology.adelaide.edu.au/virtual/glossary/]
 relationship: part_of BTO:0000281 ! conidiophore
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-29T01:37:24Z
 
 [Term]
@@ -34265,7 +34282,7 @@ id: BTO:0004749
 name: phialide
 def: "A specialized conidiogenous cell that produces conidia in basipetal succession without increasing in length." [Glossary_of_Mycological_Terms:http\://www.mycology.adelaide.edu.au/virtual/glossary/]
 relationship: part_of BTO:0000281 ! conidiophore
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-29T01:39:23Z
 
 [Term]
@@ -34273,7 +34290,7 @@ id: BTO:0004750
 name: 129S6 cell
 def: "The PluriStem 129S6 Murine ES cell line is derived from the widely used 129/S6/SvEv strain of mice." [Millipore:http\://www.millipore.com/]
 is_a: BTO:0001581 ! embryonic stem cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-29T01:57:20Z
 
 [Term]
@@ -34281,7 +34298,7 @@ id: BTO:0004751
 name: 1C9 cell
 def: "Lexicon ES cell line 1C9 from parental mouse strain 129/SvEvBrd." [Mutant_Mouse_Regional_Resource_Centers:MMRRC]
 is_a: BTO:0001581 ! embryonic stem cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-29T02:00:43Z
 
 [Term]
@@ -34292,7 +34309,7 @@ synonym: "ADSC cell" RELATED []
 synonym: "stromal vascular fraction cell" RELATED []
 synonym: "SVF cell" RELATED []
 is_a: BTO:0002064 ! stromal cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-29T02:04:53Z
 
 [Term]
@@ -34302,7 +34319,7 @@ def: "SV40-transformed polymerase- eta-deficient XP30RO fibroblasts were derived
 synonym: "XP-V (XP30RO) cell" RELATED []
 synonym: "XP30RO cell" RELATED []
 is_a: BTO:0001619 ! skin fibroblast cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-30T09:56:29Z
 
 [Term]
@@ -34312,7 +34329,7 @@ def: "Monkey (Cercopithecus aethiops) kidney endothelial cell line. It is a deri
 synonym: "VERO 76 cell" RELATED []
 synonym: "VERO76 cell" RELATED []
 relationship: develops_from BTO:0001444 ! Vero cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-30T10:12:11Z
 
 [Term]
@@ -34324,21 +34341,21 @@ synonym: "Vero E6 cell" RELATED []
 synonym: "Vero-E6 cell" RELATED []
 synonym: "VeroE6 cell" RELATED []
 relationship: develops_from BTO:0001444 ! Vero cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-30T10:17:30Z
 
 [Term]
 id: BTO:0004756
 name: venous endothelium
 is_a: BTO:0000766 ! blood vessel endothelium
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-30T10:33:04Z
 
 [Term]
 id: BTO:0004757
 name: arterial endothelium
 is_a: BTO:0000766 ! blood vessel endothelium
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-30T10:33:17Z
 
 [Term]
@@ -34346,7 +34363,7 @@ id: BTO:0004758
 name: arterial endothelial cell
 is_a: BTO:0001176 ! endothelial cell
 relationship: part_of BTO:0004757 ! arterial endothelium
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-30T10:34:56Z
 
 [Term]
@@ -34354,7 +34371,7 @@ id: BTO:0004759
 name: venous endothelial cell
 is_a: BTO:0001176 ! endothelial cell
 relationship: part_of BTO:0004756 ! venous endothelium
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-30T10:35:33Z
 
 [Term]
@@ -34363,7 +34380,7 @@ name: TF-1 cell
 def: "Human bone marrow erythroleukemia cell line. The TF-1 cell line has been established in October 1987 from a heparinized bone marrow aspiration sample from a 35 year old Japanese male with severe pancytopenia." [CLS-Cell_Lines_Service:http\://www.cell-lines-service.de/]
 is_a: BTO:0000264 ! bone marrow cell line
 is_a: BTO:0000846 ! erythroleukemia cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-30T10:40:21Z
 
 [Term]
@@ -34373,7 +34390,7 @@ def: "We used TF-1 BCR/ABL cells, by introducing the BCR/ABL gene into the TF-1 
 synonym: "TF-1 BCR/ABL cell" RELATED []
 synonym: "TF-1-Bcr-Abl cell" RELATED []
 relationship: develops_from BTO:0004760 ! TF-1 cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-30T10:44:09Z
 
 [Term]
@@ -34381,7 +34398,7 @@ id: BTO:0004762
 name: TSM1 cell
 def: "Murine neocortical neuronal cell line." [PMID:10205007]
 is_a: BTO:0000947 ! neuronal cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-09-30T10:50:38Z
 
 [Term]
@@ -34389,7 +34406,7 @@ id: BTO:0004763
 name: V866 cell
 def: "Human somatic proximal cecum colonic cancer cell line, established from a caucasian male." [PMID:19617566]
 is_a: BTO:0000797 ! colonic cancer cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-02T10:17:12Z
 
 [Term]
@@ -34397,7 +34414,7 @@ id: BTO:0004764
 name: V400 cell
 def: "Human somatic proximal colonic cancer cell line, established from a caucasian male." [PMID:19617566]
 is_a: BTO:0000797 ! colonic cancer cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-02T10:18:50Z
 
 [Term]
@@ -34405,7 +34422,7 @@ id: BTO:0004765
 name: UKE-1 cell
 def: "Acute myeloid leukemia cell line." [PMID:16408098]
 is_a: BTO:0001883 ! acute myeloid leukemia cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-02T10:22:54Z
 
 [Term]
@@ -34413,7 +34430,7 @@ id: BTO:0004766
 name: SET-2 cell
 def: "Acute myeloid leukemia cell line. Human essential thrombocythemia cell line; established from the peripheral blood of a 71-year-old woman with essential thrombocythemia at megakaryoblastic leukemic transformation." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ, PMID:16408098]
 is_a: BTO:0001883 ! acute myeloid leukemia cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-02T10:24:42Z
 
 [Term]
@@ -34421,7 +34438,7 @@ id: BTO:0004767
 name: MB-02 cell
 def: "Acute myeloid leukemia cell line." [PMID:16408098]
 is_a: BTO:0001883 ! acute myeloid leukemia cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-02T10:24:58Z
 
 [Term]
@@ -34429,7 +34446,7 @@ id: BTO:0004768
 name: MUTZ-8 cell
 def: "Acute myeloid leukemia cell line." [PMID:16408098]
 is_a: BTO:0001883 ! acute myeloid leukemia cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-02T10:25:28Z
 
 [Term]
@@ -34437,7 +34454,7 @@ id: BTO:0004769
 name: teratocyte
 def: "In Lepidoptera Pieridae, unicellular forms resulting from the embryonic membranes of parasitic Braconidae." [Online_Dictionary_of_Invertebrate_Zoology:http\://digitalcommons.unl.edu/cgi/viewcontent.cgi?article=1017&context=onlinedictinvertzoology]
 is_a: BTO:0000284 ! organism form
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-02T10:57:12Z
 
 [Term]
@@ -34445,7 +34462,7 @@ id: BTO:0004770
 name: TAD-2 cell
 def: "Immortalized normal thyroid cell line." [PMID:10372715]
 is_a: BTO:0001876 ! thyroid cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-02T10:59:47Z
 
 [Term]
@@ -34459,7 +34476,7 @@ synonym: "NPA87-1 cell" RELATED []
 synonym: "UCLA NPA871 cell" RELATED []
 synonym: "UCLA-NPA-87-1 cell" RELATED []
 relationship: develops_from BTO:0002805 ! M14 melanoma cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-02T11:01:58Z
 
 [Term]
@@ -34467,7 +34484,7 @@ id: BTO:0004772
 name: WRO cell
 def: "Follicular thyroid tumor cell line." [PMID:10372715]
 is_a: BTO:0003874 ! follicular thyroid cancer cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-02T11:03:05Z
 
 [Term]
@@ -34477,7 +34494,7 @@ def: "Tanaka et al have reported that a culture of mouse blastocysts or early po
 synonym: "TS cell line" RELATED []
 is_a: BTO:0003420 ! trophoblast cell line
 relationship: develops_from BTO:0004774 ! trophoblast stem cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-02T11:10:16Z
 
 [Term]
@@ -34486,7 +34503,7 @@ name: trophoblast stem cell
 def: "Tanaka et al have reported that a culture of mouse blastocysts or early postimplantation trophoblasts in the presence of FGF-4 permits the isolation of permanent trophoblast stem cell lines." [COPE_Cytokines_&_Cells_Online_Pathfinder_Encyclopaedia:http\://www.copewithcytokines.de/cope.cgi]
 synonym: "TS cell" RELATED []
 relationship: develops_from BTO:0001099 ! blastocyst
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-02T11:14:22Z
 
 [Term]
@@ -34494,7 +34511,7 @@ id: BTO:0004775
 name: SUP-M2 cell
 def: "Human anaplastic large cell lymphoma (ALCL) cell line; derived from the cerebrospinal fluid of a 5-year-old girl with refractory malignant histiocytosis." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 is_a: BTO:0004868 ! anaplastic large cell lymphoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-02T11:19:17Z
 
 [Term]
@@ -34504,7 +34521,7 @@ def: "Neuron projecting from the corpus striatum to the substantia nigra." [Dict
 synonym: "nigrostriatal neuron" RELATED []
 is_a: BTO:0000938 ! neuron
 relationship: part_of BTO:0000235 ! basal ganglion
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-02T11:22:43Z
 
 [Term]
@@ -34513,7 +34530,7 @@ name: RSC96 cell
 def: "Spontaneously immortalized rat Schwann cell line, derived from long-term culture of rat primary Schwann cells." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 synonym: "RSC 96 cell" RELATED []
 is_a: BTO:0001216 ! Schwann cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-02T11:37:05Z
 
 [Term]
@@ -34525,7 +34542,7 @@ synonym: "MSN" RELATED []
 synonym: "spiny projection neuron" RELATED []
 is_a: BTO:0000938 ! neuron
 relationship: part_of BTO:0001311 ! corpus striatum
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-04T08:55:16Z
 
 [Term]
@@ -34533,14 +34550,14 @@ id: BTO:0004779
 name: soft tissue sarcoma cell
 def: "A malignant tumor that begins in the muscle, fat, fibrous tissue, blood vessels, or other \"soft\" supporting tissues of the body. Soft tissue sarcomas do not originate in bone or cartilage." [Medical_Dictionary:http\://www.medterms.com/]
 is_a: BTO:0001801 ! skeletal muscle cancer cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-04T08:59:10Z
 
 [Term]
 id: BTO:0004780
 name: soft tissue sarcoma cell line
 relationship: develops_from BTO:0004779 ! soft tissue sarcoma cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-04T09:04:04Z
 
 [Term]
@@ -34548,7 +34565,7 @@ id: BTO:0004781
 name: SK-RC-26B cell
 def: "Human renal cell carcinoma cell line." [PMID:19801523]
 is_a: BTO:0000383 ! renal cell carcinoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-04T09:10:47Z
 
 [Term]
@@ -34559,7 +34576,7 @@ synonym: "BE(2)-C cell" RELATED []
 synonym: "BE(2)C cell" RELATED []
 synonym: "SK-N-BE(2)-C cell" RELATED []
 relationship: develops_from BTO:0002696 ! SK-N-BE(2) cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-04T09:13:35Z
 
 [Term]
@@ -34567,7 +34584,7 @@ id: BTO:0004783
 name: SeAx cell
 def: "The SeAx cell line is derived from peripheral blood of a patient with Sezary syndrome, a common type of cutaneous T-cell lymphoma." [PMID:_17179233]
 is_a: BTO:0003212 ! T-lymphoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-04T09:32:15Z
 
 [Term]
@@ -34575,7 +34592,7 @@ id: BTO:0004784
 name: HFF-1 cell
 def: "Human normal foreskin fibroblast cell line; pooled from two male newborn individuals." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 is_a: BTO:0002245 ! foreskin fibroblast cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-04T09:35:12Z
 
 [Term]
@@ -34585,7 +34602,7 @@ def: "Ewing sarcoma family of tumors (ESFT) belong to the group of neoplasms com
 synonym: "ESFT cell line" RELATED []
 is_a: BTO:0000400 ! sarcoma cell line
 relationship: develops_from BTO:0004255 ! Ewing's family tumor cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-04T09:40:39Z
 
 [Term]
@@ -34593,7 +34610,7 @@ id: BTO:0004786
 name: SCMC-ES1 cell
 def: "Ewing's sarcoma family tumor cell line." [PMID:18310898]
 is_a: BTO:0004785 ! Ewing's sarcoma family tumor cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-04T09:41:53Z
 
 [Term]
@@ -34601,7 +34618,7 @@ id: BTO:0004787
 name: SK-N-LO cell
 def: "Ewing's sarcoma family tumor cell line." [PMID:18310898]
 is_a: BTO:0004785 ! Ewing's sarcoma family tumor cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-04T09:52:54Z
 
 [Term]
@@ -34609,14 +34626,14 @@ id: BTO:0004788
 name: KP-EW-MS cell
 def: "Ewing's sarcoma family tumor cell line." [PMID:18310898]
 is_a: BTO:0004785 ! Ewing's sarcoma family tumor cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-04T09:53:47Z
 
 [Term]
 id: BTO:0004789
 name: ruminal fluid
 relationship: part_of BTO:0001194 ! rumen
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-04T10:01:49Z
 
 [Term]
@@ -34627,7 +34644,7 @@ synonym: "hTERT-RPE-1 cell" RELATED []
 synonym: "RPE-1 cell" RELATED []
 synonym: "RPE1 cell" RELATED []
 is_a: BTO:0002334 ! retinal pigment epithelium cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-04T10:07:18Z
 
 [Term]
@@ -34636,7 +34653,7 @@ name: root primordium
 def: "Different primordial types like the leaf and flower primordia arise from the shoot lateral meristem." [Answers.com:http\://www.answers.com/]
 is_a: BTO:0001188 ! root
 is_a: BTO:0005525 ! plant primordium
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-04T10:15:09Z
 
 [Term]
@@ -34645,7 +34662,7 @@ name: RHEK-1 cell
 def: "The human epidermal keratinocyte line, designated RHEK-1, was used at passage 23 for these transformation studies. This cell line was established from primary foreskin epidermal keratinocytes after infection with the Adl2-SV40 hybrid virus." [PMID:2405395]
 is_a: BTO:0002245 ! foreskin fibroblast cell line
 is_a: BTO:0005481 ! foreskin keratinocyte cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-04T10:27:03Z
 
 [Term]
@@ -34653,7 +34670,7 @@ id: BTO:0004793
 name: TC1 cell
 def: "Immunized T-lymphocytes which can directly destroy appropriate target cells. These CD8-positive cells are distinct from natural killer cells and from KILLER CELLS mediating antibody-dependent cell cytotoxicity. There are two effector phenotypes: TC1 and TC2." [Medical_Dictionary_Online:http\://www.online-medical-dictionary.org/]
 is_a: BTO:0000782 ! T-lymphocyte
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-04T10:32:38Z
 
 [Term]
@@ -34661,7 +34678,7 @@ id: BTO:0004794
 name: TC2 cell
 def: "Immunized T-lymphocytes which can directly destroy appropriate target cells. These CD8-positive cells are distinct from natural killer cells and from KILLER CELLS mediating antibody-dependent cell cytotoxicity. There are two effector phenotypes: TC1 and TC2." [Medical_Dictionary_Online:http\://www.online-medical-dictionary.org/]
 is_a: BTO:0000782 ! T-lymphocyte
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-04T10:35:02Z
 
 [Term]
@@ -34669,7 +34686,7 @@ id: BTO:0004795
 name: JHU-1 cell
 def: "The tumor cell line was derived from primary lung epithelial cells of C57BL/6 mice." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 is_a: BTO:0003213 ! lung epithelium cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-04T10:37:05Z
 
 [Term]
@@ -34682,7 +34699,7 @@ synonym: "253J-P cell" RELATED []
 synonym: "253J-Parental cell" RELATED []
 synonym: "253JP cell" RELATED []
 is_a: BTO:0002868 ! urinary bladder transitional cell carcinoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T09:27:24Z
 
 [Term]
@@ -34690,7 +34707,7 @@ id: BTO:0004797
 name: accessory olfactory bulb
 def: "The accessory olfactory bulb, which resides on the dorsal-posterior region of the main olfactory bulb, forms a parallel pathway independent from the main olfactory bulb. It is the second processing stage of the accessory olfactory system. It receives axonal input from the vomeronasal organ, a distinct sensory epithelium from the main olfactory epithelium that detects pheromones, among other chemical stimuli. Like the main olfactory bulb, axonal input to the accessory olfactory bulb forms synapses with mitral cells within glomeruli. However, mitral cells in the accessory olfactory bulb project their axons to targets in the amygdala and hypothalamus where they may influence aggressive and mating behavior." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0000961 ! olfactory bulb
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T09:29:44Z
 
 [Term]
@@ -34701,7 +34718,7 @@ synonym: "accessory gonad" RELATED []
 synonym: "accessory gonadal gland" RELATED []
 synonym: "male accessory gland" RELATED []
 is_a: BTO:0000080 ! male reproductive gland
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T09:32:58Z
 
 [Term]
@@ -34714,7 +34731,7 @@ synonym: "AILNCaP cell" RELATED []
 synonym: "androgen-independent LNCaP cell" RELATED []
 synonym: "LNCaPAI cell" RELATED []
 relationship: develops_from BTO:0001321 ! LNCaP cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T09:39:11Z
 
 [Term]
@@ -34723,7 +34740,7 @@ name: amnioserosa
 def: "The amnioserosa is an extraembryonic, epithelial tissue that covers the dorsal side of the Drosophila embryo." [PMID:8625823]
 synonym: "amnion-serosa" RELATED []
 is_a: BTO:0000174 ! embryonic structure
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T09:52:00Z
 
 [Term]
@@ -34737,7 +34754,7 @@ synonym: "Bm3-c2 cell" RELATED MS []
 synonym: "ML-DmBG3A-C2 cell" RELATED MS []
 is_a: BTO:0000947 ! neuronal cell line
 is_a: BTO:0002632 ! larval cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T10:10:06Z
 
 [Term]
@@ -34752,14 +34769,14 @@ creation_date: 2011-02-25T08:52:24Z
 id: BTO:0004803
 name: buccal epithelium
 relationship: part_of BTO:0003833 ! buccal mucosa
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T11:03:39Z
 
 [Term]
 id: BTO:0004804
 name: buccal epithelial cell
 relationship: part_of BTO:0004803 ! buccal epithelium
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T11:03:55Z
 
 [Term]
@@ -34767,7 +34784,7 @@ id: BTO:0004805
 name: C666-1 cell
 def: "A cell line from undifferentiated nasopharyngeal carcinoma (NPC). This cell line consistently carries the Epstein-Barr virus (EBV) in long-term cultures. C666-1 is a subclone of its parental cell line, C666, derived from an NPC xenograft of southern Chinese origin." [PMID:10449618]
 is_a: BTO:0003960 ! nasopharyngeal carcinoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T11:05:31Z
 
 [Term]
@@ -34776,7 +34793,7 @@ name: CHO-91-47-67 cell
 def: "CHO-K1 cells were stably transfected with one or more plasmids for expression of gp91phox, p47phox, and p67phox." [PMID:16895900]
 synonym: "CHO-91/47/67 cell" RELATED []
 relationship: develops_from BTO:0000457 ! CHO-K1 cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T11:15:03Z
 
 [Term]
@@ -34785,7 +34802,7 @@ name: CHO-91-22-47-67 cell
 def: "CHO-K1 cells were stably transfected with one or more plasmids for expression of gp91phox, p22phox, p47phox, and p67phox." [PMID:16895900]
 synonym: "CHOphox cell" RELATED []
 relationship: develops_from BTO:0000457 ! CHO-K1 cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T11:16:39Z
 
 [Term]
@@ -34793,7 +34810,7 @@ id: BTO:0004808
 name: CHO-91-22 cell
 def: "CHO-K1 cells were stably transfected with one or more plasmids for expression of gp91phox and p22phox." [PMID:16895900]
 relationship: develops_from BTO:0000457 ! CHO-K1 cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T11:16:44Z
 
 [Term]
@@ -34801,7 +34818,7 @@ id: BTO:0004809
 name: CHO-91 cell
 def: "CHO-K1 cells were stably transfected with one or more plasmids for expression of gp91phox." [PMID:16895900]
 relationship: develops_from BTO:0000457 ! CHO-K1 cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T11:16:48Z
 
 [Term]
@@ -34809,7 +34826,7 @@ id: BTO:0004810
 name: CHO-22 cell
 def: "CHO-K1 cells were stably transfected with one or more plasmids for expression of p22phox." [PMID:16895900]
 relationship: develops_from BTO:0000457 ! CHO-K1 cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T11:16:51Z
 
 [Term]
@@ -34819,7 +34836,7 @@ def: "Clara cells are specialized non-ciliated epithelial cells in the terminal 
 synonym: "nonciliated bronchiolar epithelial cell" RELATED []
 synonym: "nonciliated bronchiolar secretory cell" RELATED []
 relationship: part_of BTO:0003223 ! terminal bronchiole
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T11:22:42Z
 
 [Term]
@@ -34829,7 +34846,7 @@ def: "A key cell type of the resident skin immune system is the dendritic cell, 
 synonym: "DDC" RELATED []
 synonym: "dermal DC" RELATED []
 relationship: part_of BTO:0000294 ! dermis
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T11:38:10Z
 
 [Term]
@@ -34839,7 +34856,7 @@ def: "The line was established from cells from a mediastinal biopsy of a patient
 synonym: "DMS 114 cell" RELATED []
 synonym: "DMS114 cell" RELATED []
 is_a: BTO:0002206 ! small cell lung cancer cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T11:45:16Z
 
 [Term]
@@ -34852,7 +34869,7 @@ synonym: "DT40 cell" RELATED []
 synonym: "DT40B cell" RELATED []
 is_a: BTO:0001518 ! B-cell lymphoma cell line
 is_a: BTO:0001522 ! B-lymphocyte cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T11:47:40Z
 
 [Term]
@@ -34860,7 +34877,7 @@ id: BTO:0004815
 name: ER-1 cell
 def: "The ER-1 weakly malignant clonal cell line was derived from a mammary adenocarcinoma that developed spontaneously in a female SHR rat." [PMID:16959846]
 is_a: BTO:0001912 ! breast adenocarcinoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T12:02:08Z
 
 [Term]
@@ -34868,7 +34885,7 @@ id: BTO:0004816
 name: ERpP cell
 def: "ER-1 cells converted into highly tumorigenic and metastatic cells, ERpP, by subcutaneous co-inoculation with plastic plates." [PMID:9568647]
 relationship: develops_from BTO:0004815 ! ER-1 cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T12:06:29Z
 
 [Term]
@@ -34876,7 +34893,7 @@ id: BTO:0004817
 name: extraradical hypha
 def: "Extraradical hypha, of arbuscular mycorrhizal fungi, are formed outside roots and absorbing nutrients from the soil and binding its grains into aggregates." [Mycota_Dictionary:http\://www.agro.ar.szczecin.pl/~jblaszkowski/Mycota/Dictionary.html]
 is_a: BTO:0000612 ! hypha
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T12:11:19Z
 
 [Term]
@@ -34885,7 +34902,7 @@ name: FOM71 cell
 def: "Human primary melanocyte cell line." [PMID:19620624]
 synonym: "FOM 71 cell" RELATED []
 is_a: BTO:0003183 ! melanocyte cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T12:16:39Z
 
 [Term]
@@ -34894,7 +34911,7 @@ name: FOM78 cell
 def: "Human primary melanocyte cell line." [PMID:19620624]
 synonym: "FOM 78 cell" RELATED []
 is_a: BTO:0003183 ! melanocyte cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T12:18:40Z
 
 [Term]
@@ -34903,7 +34920,7 @@ name: NHEM693 cell
 def: "Human primary melanocyte cell line." [PMID:19620624]
 synonym: "NHEM 693 cell" RELATED []
 is_a: BTO:0003183 ! melanocyte cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T12:19:41Z
 
 [Term]
@@ -34912,7 +34929,7 @@ name: NHEM2493 cell
 def: "Human primary melanocyte cell line." [PMID:19620624]
 synonym: "NHEM 2493 cell" RELATED []
 is_a: BTO:0003183 ! melanocyte cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T12:19:44Z
 
 [Term]
@@ -34920,7 +34937,7 @@ id: BTO:0004822
 name: germ tube
 def: "A germ tube is an outgrowth produced by certain species of spore-releasing fungi (sporangia) during germination. The germ tube differentiates, grows, and develops by mitosis to create a somatic hyphae." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0001436 ! mycelium
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T12:23:51Z
 
 [Term]
@@ -34931,7 +34948,7 @@ synonym: "H-1355 cell" RELATED []
 synonym: "H1355 cell" RELATED []
 synonym: "NCIH1355 cell" RELATED []
 is_a: BTO:0001911 ! lung adenocarcinoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T12:32:47Z
 
 [Term]
@@ -34941,7 +34958,7 @@ def: "Human non-small cell lung cancer cell line." [ATCC_American_Cell_Type_Cult
 synonym: "H-1975 cell" RELATED []
 synonym: "H1975 cell" RELATED []
 is_a: BTO:0002553 ! non-small cell lung cancer cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T12:35:50Z
 
 [Term]
@@ -34950,7 +34967,7 @@ name: NCI-H524 cell
 def: "Human variant small cell lung cancer cell line; derived from lymph node metastasis from a 63 years old caucasian male." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 synonym: "H524 cell" RELATED []
 is_a: BTO:0002553 ! non-small cell lung cancer cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T12:39:15Z
 
 [Term]
@@ -34958,7 +34975,7 @@ id: BTO:0004826
 name: HFF2/T cell
 def: "Human foreskin fibroblasts immortalized by human telomerase reverse-transcriptase." [PMID:19393168]
 is_a: BTO:0002245 ! foreskin fibroblast cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T04:46:20Z
 
 [Term]
@@ -34968,7 +34985,7 @@ def: "Immortalized human fetal osteoblastic cell line." [PMID:12210717]
 comment: Made obsolete. Is a synonym of hFOB 1.19 cell.
 synonym: "hFOB cell" RELATED []
 is_obsolete: true
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T04:50:08Z
 
 [Term]
@@ -34976,7 +34993,7 @@ id: BTO:0004828
 name: HGC-27 cell
 def: "This human gastric carcinoma cell line was established by culture of the metastatic lymph node from a gastric cancer patient diagnosed histological as undifferentiated carcinoma." [CLS-Cell_Lines_Service:http\://www.cell-lines-service.de/]
 is_a: BTO:0000787 ! gastric cancer cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T04:53:43Z
 
 [Term]
@@ -34984,14 +35001,14 @@ id: BTO:0004829
 name: HOB-c cell
 def: "Normal human hipbone osteoblast cell line." [PMID:20459702]
 is_a: BTO:0004324 ! osteoblast cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T04:58:49Z
 
 [Term]
 id: BTO:0004830
 name: epidermal cell line
 relationship: develops_from BTO:0001470 ! epidermal cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T05:04:25Z
 
 [Term]
@@ -34999,7 +35016,7 @@ id: BTO:0004831
 name: JB6 cell
 def: "Mouse epidermal cell line." [PMID:19379505]
 is_a: BTO:0004830 ! epidermal cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T05:04:41Z
 
 [Term]
@@ -35007,7 +35024,7 @@ id: BTO:0004832
 name: L56Br-C1 cell
 def: "A human tumor xenograft (L56Br-X1) was established from a breast cancer axillary lymph node metastasis of a 53-year-old woman with a BRCA1 germ-line nonsense mutation (1806C>T; Q563X), and a cell line (L56Br-C1) was subsequently derived from the xenograft." [PMID:19379505]
 is_a: BTO:0000356 ! breast cancer cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-05T05:07:23Z
 
 [Term]
@@ -35018,7 +35035,7 @@ synonym: "large-cell neuroendocrine carcinoma cell" RELATED []
 synonym: "LCNEC" RELATED []
 is_a: BTO:0001407 ! neuroendocrine tumor cell
 is_a: BTO:0002058 ! non-small cell lung cancer cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-08T08:59:20Z
 
 [Term]
@@ -35026,7 +35043,7 @@ id: BTO:0004834
 name: middle frontal gyrus
 def: "It makes up about one-third of the frontal lobe of the human brain. A gyrus is one of the prominent bumps or ridges on the surface of the human brain. The middle frontal gyrus, like the inferior frontal gyrus and the superior frontal gyrus, is more of a region than a true gyrus. The borders of the middle frontal gyrus are the inferior frontal sulcus below; the superior frontal sulcus above; and the precentral sulcus behind." [Wikipedia:The_Free_Encyclopedia]
 relationship: part_of BTO:0000484 ! frontal lobe
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-08T09:09:10Z
 
 [Term]
@@ -35034,7 +35051,7 @@ id: BTO:0004835
 name: inferior frontal gyrus
 def: "A gyrus of the frontal lobe of the human brain. Its superior border is the inferior frontal sulcus, its inferior border the lateral fissure, and its posterior border is the inferior precentral sulcus. Above it is the middle frontal gyrus, behind it the precentral gyrus." [Wikipedia:The_Free_Encyclopedia]
 relationship: part_of BTO:0000484 ! frontal lobe
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-08T09:10:49Z
 
 [Term]
@@ -35042,7 +35059,7 @@ id: BTO:0004836
 name: superior frontal gyrus
 def: "It makes up about one-third of the frontal lobe of the human brain. It is bounded laterally by the superior frontal sulcus. The superior frontal gyrus, like the inferior frontal gyrus and the middle frontal gyrus, is more of a region than a true gyrus." [Wikipedia:The_Free_Encyclopedia]
 relationship: part_of BTO:0000484 ! frontal lobe
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-08T09:11:01Z
 
 [Term]
@@ -35050,7 +35067,7 @@ id: BTO:0004837
 name: MRC5-SV cell
 def: "This cell line is derived by simian virus 40 transformation of MRC5 fibroblasts." [PMID:2550810]
 relationship: develops_from BTO:0001590 ! MRC-5 cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-08T09:17:05Z
 
 [Term]
@@ -35061,7 +35078,7 @@ synonym: "muscularis externa" RELATED []
 synonym: "tunica externa" RELATED []
 synonym: "tunica muscularis" RELATED []
 is_a: BTO:0001260 ! smooth muscle
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-08T09:39:50Z
 
 [Term]
@@ -35071,7 +35088,7 @@ def: "The thin layer of smooth muscle found in most parts of the gastrointestina
 synonym: "lamina muscularis mucosa" RELATED []
 is_a: BTO:0001260 ! smooth muscle
 relationship: part_of BTO:0000511 ! gastrointestinal tract
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-08T09:46:00Z
 
 [Term]
@@ -35087,7 +35104,7 @@ id: BTO:0004841
 name: UCP-3 cell
 def: "The UCP-3 cell line is a low metastatic human lung carcinoma cell line." [Patent:CA_Patent_2469027]
 is_a: BTO:0001911 ! lung adenocarcinoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-08T10:29:31Z
 
 [Term]
@@ -35096,7 +35113,7 @@ name: MyLa 2039 cell
 def: "Cutaneous T-cell lymphoma (CTCL) cell line from skin. The malignant T-cell line MyLa 2039 was established from a plaque biopsy specimen of a patient with Mycosis fungoides (MF)." [PMID:17179233]
 synonym: "MyLa2039 cell" RELATED []
 is_a: BTO:0003212 ! T-lymphoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-08T10:36:53Z
 
 [Term]
@@ -35105,7 +35122,7 @@ name: MyLa 2059 cell
 def: "Cutaneous T-cell lymphoma (CTCL) cell line from skin. A subline of MyLa 2039." [PMID:17179233]
 synonym: "MyLa2059 cell" RELATED []
 relationship: develops_from BTO:0004842 ! MyLa 2039 cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-08T10:38:30Z
 
 [Term]
@@ -35113,7 +35130,7 @@ id: BTO:0004844
 name: NG2 cell
 def: "A significantly large population of glial cells in the mammalian central nervous system (CNS) that can be identified by the expression of the NG2 proteoglycan. They are found in the developing and mature CNS and are distinct from neurons, astrocytes, microglia, and mature oligodendrocytes. They are often referred to as oligodendrocyte progenitor cells because of their ability to differentiate into oligodendrocytes in culture." [PMID:11436356]
 is_a: BTO:0002606 ! glial cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-08T11:14:31Z
 
 [Term]
@@ -35121,7 +35138,7 @@ id: BTO:0004845
 name: NHOst cell
 def: "Normal female human osteoblast cell line." [PMID:12209940]
 is_a: BTO:0004324 ! osteoblast cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-08T11:18:55Z
 
 [Term]
@@ -35130,7 +35147,7 @@ name: OCUT-1 cell
 def: "Anaplastic thyroid cancer cell line." [PMID:16786150]
 synonym: "OCUT1 cell" RELATED []
 is_a: BTO:0003209 ! anaplastic thyroid cancer cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-08T11:33:42Z
 
 [Term]
@@ -35142,7 +35159,7 @@ synonym: "ONCO-DG 1 cell" RELATED []
 synonym: "ONCO-DG-1 cell" RELATED []
 synonym: "ONCODG1 cell" RELATED []
 relationship: develops_from BTO:0000812 ! OVCAR-3 cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-08T11:36:09Z
 
 [Term]
@@ -35151,7 +35168,7 @@ name: PaCa-44 cell
 def: "Human pancreatic cancer cell line." [PMID:16201853]
 synonym: "PaCa44 cell" RELATED []
 is_a: BTO:0000794 ! pancreatic cancer cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-08T11:46:16Z
 
 [Term]
@@ -35160,7 +35177,7 @@ name: pharyngeal gland
 def: "Racemose mucous glands beneath the mucous membrane of the pharynx." [Biology-Online_Dictionary:http\://www.biology-online.org/dictionary/]
 synonym: "glandulae pharyngeae" RELATED []
 relationship: part_of BTO:0001049 ! pharynx
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-08T12:38:29Z
 
 [Term]
@@ -35168,7 +35185,7 @@ id: BTO:0004850
 name: bone marrow cell
 def: "The soft, fatty, vascular tissue that fills most bone cavities and is the source of red blood cells and many white blood cells." [The_American_Heritage_Dictionary_of_the_English_Language:Fourth_Edition._2000.]
 relationship: part_of BTO:0000141 ! bone marrow
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-08T12:44:00Z
 
 [Term]
@@ -35176,7 +35193,7 @@ id: BTO:0004851
 name: mammary ductal carcinoma cell
 def: "The most common type of breast cancer in women. It comes in two forms: invasive ductal carcinoma (IDC), an infiltrating, malignant and abnormal proliferation of neoplastic cells in the breast tissue, or ductal carcinoma in situ (DCIS), a noninvasive, possibly malignant, neoplasm that is still confined to the milk ducts (lactiferous ducts), where breast cancer most often originates." [Wikipedia:The_Free_Encyclopedia]
 relationship: develops_from BTO:0002845 ! mammary duct
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-08T12:50:02Z
 
 [Term]
@@ -35185,7 +35202,7 @@ name: OV-90 cell
 def: "Human ovary malignant papillary serous adenocarcinoma cell line; derived from metastatic site: ascites." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 synonym: "OV90 cell" RELATED []
 is_a: BTO:0001882 ! ovary adenocarcinoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-08T01:05:37Z
 
 [Term]
@@ -35193,7 +35210,7 @@ id: BTO:0004853
 name: PC-3H cell
 def: "A subclone of the ATCC PC-3 cell line." [PMID:8637912]
 relationship: develops_from BTO:0001061 ! PC-3 cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-08T01:11:29Z
 
 [Term]
@@ -35201,7 +35218,7 @@ id: BTO:0004854
 name: PK-1 cell
 def: "Human cell line stablished from liver metastases of pancreatic ductal adenocarcinomas." [PMID:9665487]
 is_a: BTO:0003883 ! pancreatic ductal adenocarcinoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-08T01:14:13Z
 
 [Term]
@@ -35209,7 +35226,7 @@ id: BTO:0004855
 name: PK-8 cell
 def: "Human cell line stablished from liver metastases of pancreatic ductal adenocarcinomas." [PMID:9665487]
 is_a: BTO:0003883 ! pancreatic ductal adenocarcinoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-08T01:17:10Z
 
 [Term]
@@ -35218,7 +35235,7 @@ name: pancreaticobiliary cancer cell
 synonym: "pancreatico-biliary cancer cell" RELATED []
 is_a: BTO:0000584 ! pancreatic cancer cell
 is_a: BTO:0001326 ! cholangiocarcinoma cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-08T01:28:01Z
 
 [Term]
@@ -35234,7 +35251,7 @@ id: BTO:0004858
 name: ACT-1 cell
 def: "Human anaplastic thyroid carcinoma cell line." [PMID:19223553]
 is_a: BTO:0003209 ! anaplastic thyroid cancer cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-11T02:12:47Z
 
 [Term]
@@ -35245,7 +35262,7 @@ synonym: "Nthy ori 3.1 cell " RELATED []
 synonym: "Nthy-ori 3.1 cell" RELATED []
 synonym: "NTHY-Ori-3-1 cell" RELATED []
 is_a: BTO:0001876 ! thyroid cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-11T02:42:52Z
 
 [Term]
@@ -35253,7 +35270,7 @@ id: BTO:0004860
 name: GaMG cell
 def: "Human glioblastoma cell line." [PMID:19082468]
 is_a: BTO:0001530 ! glioblastoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-11T02:49:33Z
 
 [Term]
@@ -35263,7 +35280,7 @@ synonym: "Corti`s organ cell line" RELATED []
 synonym: "organ of Corti cell line" RELATED []
 synonym: "spiral organ of Corti cell line" RELATED []
 relationship: develops_from BTO:0001691 ! spiral organ
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-11T02:55:55Z
 
 [Term]
@@ -35274,7 +35291,7 @@ synonym: "HEI-OC-1 cell" RELATED []
 synonym: "HEIOC1 cell" RELATED []
 synonym: "House Ear Institute-Organ of Corti 1 cell" RELATED []
 is_a: BTO:0004861 ! spiral organ cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-11T02:56:31Z
 
 [Term]
@@ -35282,7 +35299,7 @@ id: BTO:0004863
 name: HLCC cell
 def: "One of 29 HeLa cell clone (HLCC) lines." [PMID:19470247]
 relationship: develops_from BTO:0000567 ! HeLa cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-11T03:30:45Z
 
 [Term]
@@ -35290,7 +35307,7 @@ id: BTO:0004864
 name: HMC cell
 def: "Human mesangial cell line." [PMID:18620493]
 is_a: BTO:0003581 ! renal glomerular cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-11T03:33:04Z
 
 [Term]
@@ -35300,7 +35317,7 @@ def: "Normal human breast cell line." [PMID:19250196]
 synonym: "Human 7 cell" RELATED []
 synonym: "Human7 cell" RELATED []
 is_a: BTO:0000816 ! breast cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-11T03:38:02Z
 
 [Term]
@@ -35313,7 +35330,7 @@ synonym: "LS-LiM6 cell" RELATED []
 synonym: "Ls-LiM6 cell" RELATED []
 synonym: "LsLiM6 cell" RELATED []
 relationship: develops_from BTO:0001553 ! LS-174T cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-11T03:44:40Z
 
 [Term]
@@ -35323,7 +35340,7 @@ def: "Human anaplastic large cell lymphoma (ALCL) cell line, a subclone of Sup-M
 synonym: "Sup-M2TS cell" RELATED []
 synonym: "TS cell" RELATED []
 relationship: develops_from BTO:0004775 ! SUP-M2 cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-11T03:51:52Z
 
 [Term]
@@ -35333,7 +35350,7 @@ def: "An aggressive (rapidly progressing) type of non-Hodgkins lymphoma that is 
 synonym: "ALCL cell line" RELATED []
 is_a: BTO:0000104 ! lymphoma cell line
 relationship: develops_from BTO:0002505 ! anaplastic large cell lymphoma cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-11T03:55:47Z
 
 [Term]
@@ -35341,7 +35358,7 @@ id: BTO:0004869
 name: Mac-1 cell
 def: "T cell lymphoblastoid line." [PMID:18845790]
 is_a: BTO:0002629 ! T-lymphoblastoid cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-11T03:59:09Z
 
 [Term]
@@ -35349,7 +35366,7 @@ id: BTO:0004870
 name: MOLT cell
 def: "A model cell line for acute lymphoblastic leukemia." [PMID:19428339]
 is_a: BTO:0002144 ! acute lymphoblastic leukemia cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-11T04:02:18Z
 
 [Term]
@@ -35357,7 +35374,7 @@ id: BTO:0004871
 name: NB-39 cell
 def: "Human neuroblastoma cell line." [PMID:18520032]
 is_a: BTO:0000932 ! neuroblastoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-11T04:05:57Z
 
 [Term]
@@ -35365,7 +35382,7 @@ id: BTO:0004872
 name: NCR-EW2 cell
 def: "Cell line derived from Ewing's sarcoma (ES)." [PMID:18520032]
 is_a: BTO:0004785 ! Ewing's sarcoma family tumor cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-11T04:07:27Z
 
 [Term]
@@ -35374,7 +35391,7 @@ name: UT-SCC-118 cell
 def: "Human squamous carcinoma cell line." [PMID:19285976]
 synonym: "UT-SCC118 cell" RELATED []
 is_a: BTO:0004438 ! HSCC cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-11T04:19:18Z
 
 [Term]
@@ -35383,7 +35400,7 @@ name: non-root-hair cell
 def: "Epidermal cells that are located over a junction between two cortex cells become root hairs (H cells), whereas the other epidermal cells become non-root-hair cells (N cells)." [PMID:12524515]
 relationship: part_of BTO:0000116 ! plant epidermis
 relationship: part_of BTO:0001192 ! rootlet
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-11T08:26:26Z
 
 [Term]
@@ -35392,7 +35409,7 @@ name: labellum
 def: "The labellum is part of an Orchid, Canna or other less known flower that serves to attract insects that pollinate the flower, and acts as a landing platform for those insects. The labellum is a modified petal and can be distinguished from the other petals and from the sepals by its large size and its often irregular shape. It is not unusual for the other two petals of an orchid flower to look like the sepals, so that the labellum stands out as distinct." [Wikipedia:The_Free_Encyclopedia]
 synonym: "plant labellum" RELATED []
 is_a: BTO:0001040 ! petal
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-12T10:25:23Z
 
 [Term]
@@ -35400,7 +35417,7 @@ id: BTO:0004876
 name: distal tip
 def: "The reproductive tract in the hermaphroditic nematode has two equivalent gonad arms. As it grows longer, that portion lying closer to the gonopore (vulva or cloaca) is termed the proximal arm, while the distal arm lies further away with the extreme end named the distal tip." [Wormatlas:http\://www.wormatlas.org/]
 relationship: part_of BTO:0000534 ! gonad
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-12T10:33:18Z
 
 [Term]
@@ -35408,7 +35425,7 @@ id: BTO:0004877
 name: distal tip cell
 def: "A somatic cell with several important functions within the gonad (ovary); it lies at the distal tip of the germline in the hermaphrodite." [Wormatlas:http\://www.wormatlas.org/]
 relationship: part_of BTO:0004876 ! distal tip
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-12T10:37:47Z
 
 [Term]
@@ -35417,7 +35434,7 @@ name: enteric muscle
 def: "Muscle cells of the posterior gut and rectum. There are four specialized muscle cells in this region that operate in the defecation cycle; the L/R stomatointestinal muscles (also called the intestinal muscles) , the anal sphincter muscle (also called the anal dilator or rectal muscle) and the anal depressor muscle (also called the depressor ani muscle). These three sets of muscles are jointly called enteric muscles and each send an arm to the DVB neuron along dorsal surface of the preanal ganglion." [Wormatlas:http\://www.wormatlas.org/]
 is_a: BTO:0000887 ! muscle
 relationship: part_of BTO:0001266 ! invertebrate muscular system
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-12T10:40:41Z
 
 [Term]
@@ -35427,7 +35444,7 @@ def: "Human malignant glioma cell line." [PMID:18395186]
 synonym: "Tu 132 cell" RELATED []
 synonym: "Tu132 cell" RELATED []
 is_a: BTO:0000711 ! glioma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-12T11:02:39Z
 
 [Term]
@@ -35437,7 +35454,7 @@ def: "Human malignant glioma cell line." [PMID:18395186]
 synonym: "Tu 113 cell" RELATED []
 synonym: "Tu113 cell" RELATED []
 is_a: BTO:0000711 ! glioma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-12T11:03:37Z
 
 [Term]
@@ -35447,7 +35464,7 @@ def: "Cancer of the parotid gland. 80% of all salivary gland tumors occur in the
 synonym: "parotid cancer cell" RELATED []
 synonym: "parotid gland cancer cell" RELATED []
 relationship: develops_from BTO:0001004 ! parotid gland
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-12T11:09:12Z
 
 [Term]
@@ -35455,7 +35472,7 @@ id: BTO:0004882
 name: ventral midbrain
 comment: Added as synonym to tegmentum.
 is_obsolete: true
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-12T11:20:09Z
 
 [Term]
@@ -35463,7 +35480,7 @@ id: BTO:0004883
 name: cystadenocarcinoma cell line
 is_a: BTO:0000811 ! ovary cancer cell line
 relationship: develops_from BTO:0004510 ! cystadenocarcinoma cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-12T01:01:09Z
 
 [Term]
@@ -35471,7 +35488,7 @@ id: BTO:0004884
 name: QZG cell
 def: "Human normal liver cell line." [PMID:20100471]
 is_a: BTO:0000224 ! liver cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-12T01:07:20Z
 
 [Term]
@@ -35480,7 +35497,7 @@ name: OSA-344 cell
 def: "Osteosarcoma cell line; established from primary osteosarcoma tissue." [PMID:20144850]
 synonym: "OSA344 cell" RELATED []
 is_a: BTO:0000407 ! osteosarcoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-12T01:09:55Z
 
 [Term]
@@ -35489,7 +35506,7 @@ name: PC-10 cell
 def: "Human non-small cell lung cancer (NSCLC) cell line." [PMID:19931513]
 synonym: "PC10 cell" RELATED []
 is_a: BTO:0002553 ! non-small cell lung cancer cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-12T05:06:50Z
 
 [Term]
@@ -35497,7 +35514,7 @@ id: BTO:0004887
 name: ACC-LC-319 cell
 def: "Human non-small cell lung cancer (NSCLC) cell line." [PMID:19931513]
 is_a: BTO:0002553 ! non-small cell lung cancer cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-12T05:09:40Z
 
 [Term]
@@ -35505,7 +35522,7 @@ id: BTO:0004888
 name: TC-1 cell
 def: "Mouse embryonic stem cell culture." [PMID:19897492]
 is_a: BTO:0001581 ! embryonic stem cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-12T05:16:13Z
 
 [Term]
@@ -35515,7 +35532,7 @@ def: "Human colon cancer cell line." [PMID:2203882]
 synonym: "BM 314 cell" RELATED []
 synonym: "BM314 cell" RELATED []
 is_a: BTO:0000797 ! colonic cancer cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-12T05:44:40Z
 
 [Term]
@@ -35525,7 +35542,7 @@ def: "Human colonic carcinoma cell line." [PMID:9184925]
 synonym: "CHCY 1 cell" RELATED []
 synonym: "CHCY1 cell" RELATED []
 is_a: BTO:0000797 ! colonic cancer cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-12T05:49:36Z
 
 [Term]
@@ -35534,7 +35551,7 @@ name: CH-27 cell
 def: "Human lung squamous carcinoma cell line." [PMID:12522090]
 synonym: "CH27 cell" RELATED []
 is_a: BTO:0002202 ! lung squamous cell carcinoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-12T06:03:07Z
 
 [Term]
@@ -35549,7 +35566,7 @@ id: BTO:0004893
 name: 253J laval cell
 def: "Human bladder cancer cell line." [PMID:18724390]
 relationship: develops_from BTO:0004796 ! 253J cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-14T09:06:10Z
 
 [Term]
@@ -35558,7 +35575,7 @@ name: 253J-BV cell
 def: "Highly metastatic variant from human transitional cell carcinoma." [PMID:7658585]
 synonym: "253J B-V cell" RELATED []
 relationship: develops_from BTO:0004796 ! 253J cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-14T09:10:48Z
 
 [Term]
@@ -35567,7 +35584,7 @@ name: NPC-TW01 cell
 def: "Human nasopharyngeal carcinoma cell line." [PMID:19330019]
 comment: NPC-TW01 cell and NPC-TW039 cell are synonyms.
 is_obsolete: true
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-14T09:16:31Z
 
 [Term]
@@ -35575,7 +35592,7 @@ id: BTO:0004896
 name: IMEC cell
 def: "TERT-immortalized human mammary epithelial cell line." [PMID:19915615]
 is_a: BTO:0002768 ! mammary epithelial cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-14T09:19:16Z
 
 [Term]
@@ -35584,7 +35601,7 @@ name: CHO-LY-B cell
 def: "Chinese hamster ovary cells strain with defective serine palmitoyltransferase." [PMID:19536577]
 synonym: "LY-B cell" RELATED []
 relationship: develops_from BTO:0000246 ! CHO cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-14T09:40:39Z
 
 [Term]
@@ -35592,7 +35609,7 @@ id: BTO:0004898
 name: HML-Gb3 cell
 def: "HeLa cell line stably transfected with pML-Gb3Sp (globotriaosylceramide synthase gene)." [PMID:19674101]
 relationship: develops_from BTO:0000567 ! HeLa cell
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-14T09:50:38Z
 
 [Term]
@@ -35600,7 +35617,7 @@ id: BTO:0004899
 name: HK-1 cell
 def: "EBV-negative nasopharyngeal carcinoma cell line." [PMID:19674101]
 is_a: BTO:0003960 ! nasopharyngeal carcinoma cell line
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-14T09:59:03Z
 
 [Term]
@@ -35608,7 +35625,7 @@ id: BTO:0004900
 name: pulmonary venous myocardium
 def: "The pulmonary venous myocardium represents the extension of atrial myocardium into the vascular wall of the pulmonary vein." [PMID:19470375]
 is_a: BTO:0000901 ! myocardium
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-14T10:30:39Z
 
 [Term]
@@ -35617,7 +35634,7 @@ name: non-neuronal cell
 def: "Cell pertaining to or composed of nonconducting cells of the nervous system, e.g. neuroglial cells." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 synonym: "nonneuronal cell" RELATED []
 relationship: part_of BTO:0001484 ! nervous system
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-14T11:19:48Z
 
 [Term]
@@ -35626,7 +35643,7 @@ name: cholinergic neuron
 def: "Nerves which synthesize the neurotransmitter acetylcholine in their terminals; they include alpha-motor neurons of the spinal cord, cranial nerves innervating skeletal muscle, preganglionic sympathetic and postganglionic parasympathetic neurons." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 is_a: BTO:0000925 ! nerve
 is_a: BTO:0000938 ! neuron
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-14T11:23:23Z
 
 [Term]
@@ -35635,7 +35652,7 @@ name: plant crown
 def: "1. The upper part of a tree, which includes the branches and leaves. 2. The part of a plant, usually at ground level, where the stem and roots merge. 3. The persistent, mostly underground base of a perennial herb." [Dictionary:http\://www.thefreedictionary.com/]
 synonym: "crown" RELATED []
 relationship: part_of BTO:0001461 ! whole plant
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-14T11:55:27Z
 
 [Term]
@@ -35643,7 +35660,7 @@ id: BTO:0004904
 name: hair follicle bulge
 def: "The bulge is located in the outer root sheath at the insertion point of the arrector pili muscle. It houses several types of stem cells, which supply the entire hair follicle with new cells, and take part in healing the epidermis after a wound." [Answers.com:http\://www.answers.com/]
 relationship: part_of BTO:0003969 ! hair follicle outer root sheath
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-14T12:21:55Z
 
 [Term]
@@ -35653,7 +35670,7 @@ def: "The putative bulge stem cells can contribute to the epidermis, outer root 
 synonym: "bulge stem cell" RELATED []
 synonym: "hair bulge stem cell" RELATED []
 relationship: part_of BTO:0004904 ! hair follicle bulge
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-14T12:22:56Z
 
 [Term]
@@ -35662,7 +35679,7 @@ name: molecular layer
 def: "1. The outer layer of the cortex of the cerebellum and cerebrum consisting of a mass of unmyelinated fibers rich in synapses. 2. Either of the two plexiform layers of the retina." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/molecular_layer]
 relationship: part_of BTO:0000043 ! cerebellar cortex
 relationship: part_of BTO:0000233 ! cerebral cortex
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-14T12:37:59Z
 
 [Term]
@@ -35672,7 +35689,7 @@ def: "A specialized form of astrocytes in the Purkinje cell layer of the cerebel
 synonym: "Bergmann's glia" RELATED []
 is_a: BTO:0000099 ! astrocyte
 relationship: part_of BTO:0004909 ! Purkinje layer
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-14T12:42:54Z
 
 [Term]
@@ -35680,7 +35697,7 @@ id: BTO:0004908
 name: Bergmann fiber
 def: "Filamentous glia fibers traversing the cerebellar cortex perpendicular to the surface. These fibers are the processes of Golgi epithelial cells." [Medical_Dictionary:http\://www.medilexicon.com/]
 is_a: BTO:0004907 ! Bergmanns glia
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-14T12:47:14Z
 
 [Term]
@@ -35689,7 +35706,7 @@ name: Purkinje layer
 def: "The cerebellar cortex is divided into three layers. At the bottom lies the thick granular layer. In the middle lies the Purkinje layer, a narrow zone that contains only the cell bodies of Purkinje cells. At the top lies the molecular layer." [Wikipedia:The_Free_Encyclopedia]
 synonym: "Purkinje cell layer" RELATED []
 relationship: part_of BTO:0000043 ! cerebellar cortex
-created_by: mgr
+created_by: Marion Gremse
 creation_date: 2010-10-14T12:52:12Z
 
 [Term]
@@ -35699,7 +35716,7 @@ def: "A cell of the pigment cell layer that nourishes the retinal cells; located
 synonym: "retinal pigment epithelial cell" RELATED []
 synonym: "RPE cell" RELATED []
 relationship: part_of BTO:0001177 ! retinal pigment epithelium
-created_by: marion
+created_by: Marion Gremse
 creation_date: 2010-10-25T05:06:24Z
 
 [Term]
@@ -35707,14 +35724,14 @@ id: BTO:0004911
 name: erythroid progenitor cell
 def: "Committed, erythroid stem cells derived from myeloid stem cells. The progenitor cells develop in two phases: erythroid burst-forming units (bfu-e) followed by erythroid colony-forming units (cfu-e). Bfu-e differentiate into cfu-e on stimulation by erythropoietin, and then further differentiate into erythroblasts when stimulated by other factors." [Biology-Online_Dictionary:http\://www.biology-online.org/dictionary/]
 relationship: develops_from BTO:0004731 ! lymphoid progenitor cell
-created_by: marion
+created_by: Marion Gremse
 creation_date: 2010-10-25T05:15:19Z
 
 [Term]
 id: BTO:0004912
 name: culture condition:peptone-yeast extract-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: marion
+created_by: Marion Gremse
 creation_date: 2010-10-25T07:49:08Z
 
 [Term]
@@ -35723,7 +35740,7 @@ name: vastus medialis
 def: "One of the four muscles of the quadriceps femoris group, situated in the medial part of the thigh. The muscle functions in combination with other parts of the quadriceps femoris to extend the leg." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 synonym: "vastus internus" RELATED []
 relationship: part_of BTO:0001149 ! quadriceps
-created_by: marion
+created_by: Marion Gremse
 creation_date: 2010-10-27T09:15:43Z
 
 [Term]
@@ -35734,7 +35751,7 @@ synonym: "RASF" RELATED []
 synonym: "rheumatoid arthritis synovial fibroblast" RELATED []
 relationship: develops_from BTO:0001336 ! synovial fibroblast
 relationship: part_of BTO:0003702 ! rheumatoid arthritis disease specific synovial tissue
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-27T09:50:12Z
 
 [Term]
@@ -35743,7 +35760,7 @@ name: ZR-75-30 cell
 def: "Human mammary gland ductal carcinoma cell line; derived from malignant ascites fluid from a 47-year-old premenopausal Black woman with infiltrating ductal carcinoma." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 synonym: "ZR75-30 cell" RELATED []
 is_a: BTO:0004086 ! mammary gland tumor cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-27T10:23:56Z
 
 [Term]
@@ -35751,7 +35768,7 @@ id: BTO:0004916
 name: ZR-78 cell
 def: "ZR-78 is a peroxisome-deficient mutant cell line obtained from ethyl methanesulfonate-treated stocks of CHO-K1." [PMID:7685346]
 relationship: develops_from BTO:0000457 ! CHO-K1 cell
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-27T10:27:14Z
 
 [Term]
@@ -35759,7 +35776,7 @@ id: BTO:0004917
 name: ZR-78.1 cell
 def: "Strain ZR-78.1 is a hypoxanthine phosphoribosyltransferase-deficient and ouabain-resistant subclone of ZR-78." [PMID:7685346]
 relationship: develops_from BTO:0004916 ! ZR-78 cell
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-27T10:28:42Z
 
 [Term]
@@ -35767,7 +35784,7 @@ id: BTO:0004918
 name: ZR-82 cell
 def: "ZR-82 is a peroxisome-deficient mutant cell line obtained from ethyl methanesulfonate-treated stocks of CHO-K1." [PMID:7685346]
 relationship: develops_from BTO:0000457 ! CHO-K1 cell
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-27T10:28:59Z
 
 [Term]
@@ -35775,7 +35792,7 @@ id: BTO:0004919
 name: ZR-75 cell
 def: "Human non-invasive mammary gland breast cancer cell line." [PMID:19192273]
 is_a: BTO:0004086 ! mammary gland tumor cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-27T10:41:05Z
 
 [Term]
@@ -35784,7 +35801,7 @@ name: WSS-1 cell
 def: "This line was derived from the human embryonic kidney line 293, transfected with an expression plasmid containing cDNA encoding the rat GABA-A receptor alpha 1, beta 2 and gamma 2 subunits." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 synonym: "WS-1 cell" RELATED []
 relationship: develops_from BTO:0000007 ! HEK-293 cell
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-27T11:02:06Z
 
 [Term]
@@ -35794,7 +35811,7 @@ def: "Sus scrofa normal testicular cell line, established from a male 80-90 days
 synonym: "ST cell" RELATED []
 synonym: "swine testis cell line" RELATED []
 is_a: BTO:0004229 ! testicular cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-27T11:11:23Z
 
 [Term]
@@ -35804,7 +35821,7 @@ def: "Human ovarian carcinoma cell line, derived from serous cystadenocarcinoma.
 is_a: BTO:0001882 ! ovary adenocarcinoma cell line
 is_a: BTO:0003804 ! ovarian serous adenocarcinoma cell line
 is_a: BTO:0004883 ! cystadenocarcinoma cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-27T11:23:58Z
 
 [Term]
@@ -35815,7 +35832,7 @@ synonym: "NOS2 cell" RELATED []
 is_a: BTO:0001882 ! ovary adenocarcinoma cell line
 is_a: BTO:0003804 ! ovarian serous adenocarcinoma cell line
 is_a: BTO:0004883 ! cystadenocarcinoma cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-27T11:24:56Z
 
 [Term]
@@ -35826,7 +35843,7 @@ synonym: "NOS4 cell" RELATED []
 is_a: BTO:0001882 ! ovary adenocarcinoma cell line
 is_a: BTO:0003804 ! ovarian serous adenocarcinoma cell line
 is_a: BTO:0004883 ! cystadenocarcinoma cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-27T11:25:34Z
 
 [Term]
@@ -35836,7 +35853,7 @@ def: "Human ovarian carcinoma cell line; derived from serous cystadenocarcinoma.
 is_a: BTO:0001882 ! ovary adenocarcinoma cell line
 is_a: BTO:0003804 ! ovarian serous adenocarcinoma cell line
 is_a: BTO:0004883 ! cystadenocarcinoma cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-27T11:26:09Z
 
 [Term]
@@ -35844,7 +35861,7 @@ id: BTO:0004926
 name: THP-6 cell
 def: "Human acute lymphoblastic leukemia cell line from two children with null cell type ALL." [PMID:2954268]
 is_a: BTO:0002144 ! acute lymphoblastic leukemia cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-27T01:42:40Z
 
 [Term]
@@ -35852,7 +35869,7 @@ id: BTO:0004927
 name: THP-8 cell
 def: "Human acute lymphoblastic leukemia cell line from two children with null cell type ALL." [PMID:2954268]
 is_a: BTO:0002144 ! acute lymphoblastic leukemia cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-27T01:43:54Z
 
 [Term]
@@ -35865,7 +35882,7 @@ synonym: "SUM-159 cell" RELATED []
 synonym: "SUM159 cell" RELATED []
 synonym: "SUM159PT cell" RELATED []
 is_a: BTO:0005932 ! SUM cell
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-27T01:54:02Z
 
 [Term]
@@ -35875,7 +35892,7 @@ def: "Human ovarian mesonephroid adenocarcinoma cell line." [Japanese_Collection
 synonym: "RMG-2 cell" RELATED []
 synonym: "RMG2 cell" RELATED []
 is_a: BTO:0001882 ! ovary adenocarcinoma cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T09:26:34Z
 
 [Term]
@@ -35885,7 +35902,7 @@ def: "Human tumor cell line from ovarian mesonephroid adenocarcinoma." [Japanese
 synonym: "RMG-1 cell" RELATED []
 synonym: "RMG1 cell" RELATED []
 is_a: BTO:0001882 ! ovary adenocarcinoma cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T09:27:50Z
 
 [Term]
@@ -35903,7 +35920,7 @@ name: RCC-10 cell
 def: "Human renal clear cell carcinoma cell line." [PMID:15985433]
 synonym: "RCC10 cell" RELATED []
 is_a: BTO:0000383 ! renal cell carcinoma cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T09:47:46Z
 
 [Term]
@@ -35911,7 +35928,7 @@ id: BTO:0004933
 name: NALM-17 cell
 def: "B-precursor acute lymphoblastic leukemia cell line." [PMID:14504097]
 is_a: BTO:0000603 ! pre-B acute lymphoblastic leukemia cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T10:01:38Z
 
 [Term]
@@ -35919,7 +35936,7 @@ id: BTO:0004934
 name: NALM-20 cell
 def: "B-precursor acute lymphoblastic leukemia cell line." [PMID:14504097]
 is_a: BTO:0000603 ! pre-B acute lymphoblastic leukemia cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T10:05:07Z
 
 [Term]
@@ -35927,7 +35944,7 @@ id: BTO:0004935
 name: NALM-24 cell
 def: "B-precursor acute lymphoblastic leukemia cell line." [PMID:14504097]
 is_a: BTO:0000603 ! pre-B acute lymphoblastic leukemia cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T10:05:20Z
 
 [Term]
@@ -35935,7 +35952,7 @@ id: BTO:0004936
 name: NALM-26 cell
 def: "B-precursor acute lymphoblastic leukemia cell line." [PMID:14504097]
 is_a: BTO:0000603 ! pre-B acute lymphoblastic leukemia cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T10:05:45Z
 
 [Term]
@@ -35943,7 +35960,7 @@ id: BTO:0004937
 name: KOCL-33 cell
 def: "B-precursor acute lymphoblastic leukemia cell line." [PMID:14504097]
 is_a: BTO:0000603 ! pre-B acute lymphoblastic leukemia cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T10:06:42Z
 
 [Term]
@@ -35951,7 +35968,7 @@ id: BTO:0004938
 name: KOCL-44 cell
 def: "B-precursor acute lymphoblastic leukemia cell line." [PMID:14504097]
 is_a: BTO:0000603 ! pre-B acute lymphoblastic leukemia cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T10:07:07Z
 
 [Term]
@@ -35959,7 +35976,7 @@ id: BTO:0004939
 name: KOCL-45 cell
 def: "B-precursor acute lymphoblastic leukemia cell line." [PMID:14504097]
 is_a: BTO:0000603 ! pre-B acute lymphoblastic leukemia cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T10:07:22Z
 
 [Term]
@@ -35967,7 +35984,7 @@ id: BTO:0004940
 name: KOCL-58 cell
 def: "B-precursor acute lymphoblastic leukemia cell line." [PMID:14504097]
 is_a: BTO:0000603 ! pre-B acute lymphoblastic leukemia cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T10:07:41Z
 
 [Term]
@@ -35975,7 +35992,7 @@ id: BTO:0004941
 name: KOCL-69 cell
 def: "B-precursor acute lymphoblastic leukemia cell line." [PMID:14504097]
 is_a: BTO:0000603 ! pre-B acute lymphoblastic leukemia cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T10:07:51Z
 
 [Term]
@@ -35983,7 +36000,7 @@ id: BTO:0004942
 name: HAL-01 cell
 def: "B-precursor acute lymphoblastic leukemia cell line." [PMID:14504097]
 is_a: BTO:0000603 ! pre-B acute lymphoblastic leukemia cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T10:08:17Z
 
 [Term]
@@ -35991,7 +36008,7 @@ id: BTO:0004943
 name: KOPN-41 cell
 def: "B-precursor acute lymphoblastic leukemia cell line." [PMID:14504097]
 is_a: BTO:0000603 ! pre-B acute lymphoblastic leukemia cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T10:08:30Z
 
 [Term]
@@ -35999,7 +36016,7 @@ id: BTO:0004944
 name: KOPN-1 cell
 def: "B-precursor acute lymphoblastic leukemia cell line." [PMID:14504097]
 is_a: BTO:0000603 ! pre-B acute lymphoblastic leukemia cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T10:08:50Z
 
 [Term]
@@ -36007,7 +36024,7 @@ id: BTO:0004945
 name: LC4-1 cell
 def: "B-precursor acute lymphoblastic leukemia cell line." [PMID:14504097]
 is_a: BTO:0000603 ! pre-B acute lymphoblastic leukemia cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T10:09:17Z
 
 [Term]
@@ -36015,7 +36032,7 @@ id: BTO:0004946
 name: UTP-L5 cell
 def: "B-precursor acute lymphoblastic leukemia cell line." [PMID:14504097]
 is_a: BTO:0000603 ! pre-B acute lymphoblastic leukemia cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T10:09:34Z
 
 [Term]
@@ -36023,7 +36040,7 @@ id: BTO:0004947
 name: UTP-L10 cell
 def: "B-precursor acute lymphoblastic leukemia cell line." [PMID:14504097]
 is_a: BTO:0000603 ! pre-B acute lymphoblastic leukemia cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T10:09:53Z
 
 [Term]
@@ -36031,7 +36048,7 @@ id: BTO:0004948
 name: UTP-2 cell
 def: "B-precursor acute lymphoblastic leukemia cell line." [PMID:14504097]
 is_a: BTO:0000603 ! pre-B acute lymphoblastic leukemia cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T10:10:01Z
 
 [Term]
@@ -36039,7 +36056,7 @@ id: BTO:0004949
 name: SCMC-L10 cell
 def: "B-precursor acute lymphoblastic leukemia cell line." [PMID:14504097]
 is_a: BTO:0000603 ! pre-B acute lymphoblastic leukemia cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T10:10:28Z
 
 [Term]
@@ -36047,7 +36064,7 @@ id: BTO:0004950
 name: BV173 cell
 def: "B-precursor acute lymphoblastic leukemia cell line." [PMID:14504097]
 is_a: BTO:0000603 ! pre-B acute lymphoblastic leukemia cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T10:10:54Z
 
 [Term]
@@ -36055,7 +36072,7 @@ id: BTO:0004951
 name: NALL-1 cell
 def: "Human null cell from acute lymphoblastic leukemia cell line." [Japanese_Collection_of_Research_Bioresources:http\://cellbank.nibio.go.jp/]
 is_a: BTO:0002144 ! acute lymphoblastic leukemia cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T10:12:56Z
 
 [Term]
@@ -36069,7 +36086,7 @@ synonym: "Metastatic Variant-522 cell" RELATED []
 synonym: "MV- 522 cell" RELATED []
 synonym: "MV522 cell" RELATED []
 relationship: develops_from BTO:0000182 ! HT-29 cell
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T10:36:53Z
 
 [Term]
@@ -36078,7 +36095,7 @@ name: MGC-803 cell
 def: "Human gastric cancer cell line." [PMID:16077903]
 synonym: "MGC803 cell" RELATED []
 is_a: BTO:0000787 ! gastric cancer cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T10:50:02Z
 
 [Term]
@@ -36087,7 +36104,7 @@ name: capillary endothelium
 def: "The walls of capillaries are composed of only a single layer of cells, the endothelium." [Webster's_Online_Dictionary:http\://www.websters-online-dictionary.org/]
 is_a: BTO:0000766 ! blood vessel endothelium
 relationship: part_of BTO:0002045 ! capillary
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T11:16:05Z
 
 [Term]
@@ -36098,7 +36115,7 @@ synonym: "B02 cell" RELATED []
 synonym: "MDA-B02 cell" RELATED []
 synonym: "MDA-MB-231/B02 cell" RELATED []
 relationship: develops_from BTO:0000815 ! MDA-MB-231 cell
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T11:00:01Z
 
 [Term]
@@ -36106,7 +36123,7 @@ id: BTO:0004956
 name: capillary endothelial cell
 def: "A cell of the capillary endothelium." [Webster's_Online_Dictionary:http\://www.websters-online-dictionary.org/]
 relationship: part_of BTO:0004954 ! capillary endothelium
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T11:17:39Z
 
 [Term]
@@ -36114,7 +36131,7 @@ id: BTO:0004957
 name: hydathode
 def: "A specialized pore on the leaves of higher plants that functions in the exudation of water." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/hydathode]
 relationship: part_of BTO:0000713 ! leaf
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T11:26:39Z
 
 [Term]
@@ -36122,7 +36139,7 @@ id: BTO:0004958
 name: F9-12 cell
 def: "The yeast genomic DNA from the strain F9 was transferred to the established mouse fibroblast cell line L A-9 by fusion with yeast spheroplasts followed by selection with G418 to select for cells which had taken up yeast DNA. Seventeen independent cell lines, called F9-1 to F9-17, were grown up from colonies on separate plates." [PMID:8710496]
 is_a: BTO:0001926 ! hybridoma cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T12:29:08Z
 
 [Term]
@@ -36132,7 +36149,7 @@ def: "LNCaP-derivative C4-2B prostate cancer cell line." [PMID:11351351]
 synonym: "C4-2B cell" RELATED []
 synonym: "LNCAP C4-2B cell" RELATED []
 relationship: develops_from BTO:0001321 ! LNCaP cell
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T12:35:25Z
 
 [Term]
@@ -36142,7 +36159,7 @@ def: "Acute megakaryoblastic leukemia cell line." [Japanese_Collection_of_Resear
 synonym: "CMK86 cell" RELATED []
 is_a: BTO:0004961 ! acute megakaryoblastic leukemia cell line
 relationship: develops_from BTO:0000978 ! CMK cell
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T12:38:14Z
 
 [Term]
@@ -36151,7 +36168,7 @@ name: acute megakaryoblastic leukemia cell line
 def: "Acute megakaryoblastic leukemia is a form of leukemia where a majority of the blasts are megakaryoblastic." [Wikipedia:The_Free_Encyclopedia]
 synonym: "AMKL cell line" RELATED []
 is_a: BTO:0000737 ! leukemia cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T12:39:53Z
 
 [Term]
@@ -36161,7 +36178,7 @@ def: "Acute megakaryocytic leukemia is a rare subtype of acute myeloid leukemia 
 synonym: "AMegL cell" RELATED []
 is_a: BTO:0001271 ! leukemia cell
 is_a: BTO:0001549 ! megakaryocyte cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T12:45:45Z
 
 [Term]
@@ -36170,7 +36187,7 @@ name: acute megakaryoblastic leukemia cell
 def: "Acute megakaryoblastic leukemia is a form of leukemia where a majority of the blasts are megakaryoblastic." [Wikipedia:The_Free_Encyclopedia]
 synonym: "AMKL cell" RELATED []
 is_a: BTO:0001271 ! leukemia cell
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T12:45:49Z
 
 [Term]
@@ -36179,7 +36196,7 @@ name: KOPT-K1 cell
 def: "Human T-ALL cell line." [United_States_Patent_Application:20070077245]
 is_a: BTO:0002144 ! acute lymphoblastic leukemia cell line
 is_a: BTO:0002504 ! T-lymphoblastic leukemia cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T12:54:23Z
 
 [Term]
@@ -36196,7 +36213,7 @@ name: Rat-1/BB16 cell
 def: "Rat-1 cells expressing a stable v-Src protein." [PMID:8856496]
 synonym: "BB16 cell" RELATED []
 relationship: develops_from BTO:0003293 ! Rat-1 cell
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T01:12:23Z
 
 [Term]
@@ -36204,7 +36221,7 @@ id: BTO:0004967
 name: Rat-1/tsLA29 cell
 def: "Rat-1 cells expressing a thermosensitive v-Src protein." [PMID:8856496]
 relationship: develops_from BTO:0003293 ! Rat-1 cell
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T01:14:32Z
 
 [Term]
@@ -36216,7 +36233,7 @@ synonym: "NS/O cell" RELATED []
 synonym: "NS0 cell" RELATED []
 synonym: "NSO cell" RELATED []
 relationship: develops_from BTO:0001907 ! P3/NS1/1-Ag4.1 cell
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-29T01:51:22Z
 
 [Term]
@@ -36224,7 +36241,7 @@ id: BTO:0004969
 name: KOC-5C cell
 def: "Human ovarian clear cell adenocarcinoma cell line." [PMID:15534119]
 is_a: BTO:0006415 ! ovary clear cell adenocarcinoma cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T01:22:59Z
 
 [Term]
@@ -36232,7 +36249,7 @@ id: BTO:0004970
 name: KOC-7C cell
 def: "Human ovarian clear cell adenocarcinoma cell line." [PMID:15534119]
 is_a: BTO:0006415 ! ovary clear cell adenocarcinoma cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T01:24:01Z
 
 [Term]
@@ -36240,7 +36257,7 @@ id: BTO:0004971
 name: 1BR3.G cell
 def: "Human skin fibroblast cell line." [PMID:20385563]
 is_a: BTO:0001619 ! skin fibroblast cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T01:31:26Z
 
 [Term]
@@ -36249,7 +36266,7 @@ name: KM-H2 cell
 def: "Human Hodgkin lymphoma cell line, established from the pleural effusion of a 37-year-old man with Hodgkin lymphoma (mixed cellularity progressing to lymphocyte depletion; stage IV at relapse) in 1974." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 synonym: "KMH2 cell" RELATED []
 is_a: BTO:0004973 ! Hodgkin lymphoma cell line
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T01:34:23Z
 
 [Term]
@@ -36258,7 +36275,7 @@ name: Hodgkin lymphoma cell line
 def: "A disease of the lymph nodes named after the English physician Thomas Hodgkin." [Medical_Dictionary:http\://www.medterms.com/]
 is_a: BTO:0000104 ! lymphoma cell line
 relationship: develops_from BTO:0004974 ! Hodgkin lymphoma cell
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T01:35:51Z
 
 [Term]
@@ -36266,14 +36283,14 @@ id: BTO:0004974
 name: Hodgkin lymphoma cell
 def: "A disease of the lymph nodes named after the English physician Thomas Hodgkin." [Medical_Dictionary:http\://www.medterms.com/]
 is_a: BTO:0000785 ! lymphoma cell
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-28T01:37:17Z
 
 [Term]
 id: BTO:0004975
 name: embryogenic cell line
 relationship: develops_from BTO:0001233 ! plant embryo
-created_by: Marion Gremse
+created_by: Marion Gremse Gremse
 creation_date: 2010-10-29T05:01:42Z
 
 [Term]
@@ -38675,7 +38692,6 @@ creation_date: 2011-10-03T08:30:58Z
 id: BTO:0005255
 name: RPMI-1788 cell
 def: "Human B-lymphocyte cell line." [CLS-Cell_Lines_Service:http\://www.cell-lines-service.de/]
-synonym: "<new synonym>" RELATED []
 synonym: "GM02131 cell" RELATED []
 synonym: "GM02131A cell" RELATED []
 synonym: "GM17219 cell" RELATED []
@@ -40322,17 +40338,18 @@ id: BTO:0005444
 name: root nodule primordium
 def: "To form a root nodule primordium, fully differentiated root cortical cells have to be developmentally reprogrammed, which starts with mitotic activation of these cells. This is induced by Nod factors and leads to the formation of nodule primordia. Upon infection by rhizobia these primordia subsequently differentiate in nodules." [PMID:15951289, Rene_Geurts_:A_GENETIC_APPROACH_TO_STUDY_RHIZOBIAL_NOD_FACTOR_AND_MYCORRHIZAL_FUNGI_ACTIVATED_SIGNALING]
 is_a: BTO:0004791 ! root primordium
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2013-11-07T08:56:21Z
 
 [Term]
 id: BTO:0005445
 name: rectal epithelium
-def: "Epithelium of the rectum." [curators:mgr]
+def: "Epithelium of the rectum." []
 synonym: "rectum epithelium" RELATED []
 relationship: part_of BTO:0001158 ! rectum
 created_by: XPMUser
 creation_date: 2013-04-26T10:08:43Z
+created_by: Marion Gremse
 
 [Term]
 id: BTO:0005446
@@ -40860,7 +40877,7 @@ def: "An enclosure in which spores are formed. It can be composed of a single ce
 synonym: "sporangium" RELATED []
 is_a: BTO:0001285 ! sporangiophore
 relationship: part_of BTO:0005505 ! fungal sporangiophore
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2013-11-07T09:40:52Z
 
 [Term]
@@ -40869,42 +40886,42 @@ name: fungal sporangiophore
 def: "A stalk or similar structure bearing sporangia in plants and fungi." [PAE_Virtual_Glossary:Plants\,_Animals_and_the_Environment_Glossary_derived_from_leading_WCB/McGraw-Hill_textbooks]
 synonym: "sporangiophore" RELATED []
 relationship: part_of BTO:0000487 ! fruit body
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2013-11-07T09:43:27Z
 
 [Term]
 id: BTO:0005506
 name: culture condition:H2-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2013-09-20T02:43:24Z
 
 [Term]
 id: BTO:0005507
 name: culture condition:H2/sulfate-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2013-09-20T02:51:34Z
 
 [Term]
 id: BTO:0005508
 name: culture condition:ferric citrate-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2013-09-20T02:54:22Z
 
 [Term]
 id: BTO:0005509
 name: culture condition:2-aminophenol-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2013-09-20T02:56:04Z
 
 [Term]
 id: BTO:0005510
 name: culture condition:2-phenylethanol-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2013-09-20T02:56:38Z
 
 [Term]
@@ -40912,7 +40929,7 @@ id: BTO:0005511
 name: embryonic carcinoma cell
 synonym: "embryonic cancer cell" RELATED []
 relationship: develops_from BTO:0000379 ! embryo
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2013-09-20T03:44:52Z
 
 [Term]
@@ -40920,7 +40937,7 @@ id: BTO:0005512
 name: basal node
 def: "The node or joint at the base of the stem." [Encyclopedic_Dictionary_of_Plant_Breeding:2003_p52]
 is_a: BTO:0001156 ! node
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2013-10-16T12:41:13Z
 
 [Term]
@@ -40928,7 +40945,7 @@ id: BTO:0005513
 name: cercaria
 def: "A usually tadpole-shaped larval trematode worm that develops in a molluscan host from a redia." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/cercaria]
 is_a: BTO:0000707 ! larva
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2013-10-16T12:45:33Z
 
 [Term]
@@ -40937,7 +40954,7 @@ name: gonadal sheath cell
 def: "In Caenorhabditis elegans, specialized contractile myoepithelial cells of the somatic gonad, the gonadal sheath cells, are closely apposed to oocytes and are required for normal meiotic maturation and ovulation." [PMID:9405097]
 is_a: BTO:0002309 ! myoepithelial cell
 relationship: part_of BTO:0000534 ! gonad
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2013-10-16T12:51:49Z
 
 [Term]
@@ -40945,7 +40962,7 @@ id: BTO:0005515
 name: leaf vein
 def: "The veins are the vascular tissue of the leaf and are located in the sponge layer of the mesophyll." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0000713 ! leaf
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2013-10-16T12:57:11Z
 
 [Term]
@@ -40953,7 +40970,7 @@ id: BTO:0005516
 name: wood
 def: "Wood is a hard, fibrous structural xylem tissue found in the stems and roots of trees and other woody plants." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0001468 ! xylem
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2013-10-16T13:01:35Z
 
 [Term]
@@ -40964,7 +40981,7 @@ synonym: "cryodesiccated cell" RELATED []
 synonym: "freeze-dried cell" RELATED []
 synonym: "lyophilised cell" RELATED []
 is_a: BTO:0000214 ! cell culture
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2013-10-16T13:05:01Z
 
 [Term]
@@ -40973,7 +40990,7 @@ name: PC-9 cell
 def: "A cell line derived from human lung adenocarcinoma." [RIKEN_BioResource_Center:http\://www2.brc.riken.jp/]
 synonym: "PC9 cell" RELATED []
 is_a: BTO:0001911 ! lung adenocarcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2013-10-16T14:34:08Z
 
 [Term]
@@ -40982,7 +40999,7 @@ name: spermathecal-uterine valve
 def: "A single syncytium cell of four nuclei makes a valve, connecting spermatheca and uterus of hermaphrodite gonad. After oocyte fertilization the newly formed embryo passes from the spermatheca to the uterus via a connecting valve called the spermatheca-uterus valve." [Wormatlas:http\://www.wormatlas.org/]
 synonym: "spermatheca-uterus valve" RELATED []
 is_a: BTO:0003099 ! internal female genital organ
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2013-10-16T15:00:38Z
 
 [Term]
@@ -40990,7 +41007,7 @@ id: BTO:0005520
 name: uterine seam cell
 def: "Caenorhabditis elegans membranous cell attaches the uterus to the lateral epidermis (seam) and forms a thin laminar process dorsal to the vulva." [Wormatlas:http\://www.wormatlas.org/]
 is_a: BTO:0003099 ! internal female genital organ
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2013-10-16T17:44:20Z
 
 [Term]
@@ -40999,7 +41016,7 @@ name: GM0536 cell
 def: "Human EBV-transformed lymphoblastoid cell line." [PMID:22850745]
 synonym: "GMO536 cell" RELATED []
 is_a: BTO:0000773 ! lymphoblastoid cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2013-10-17T11:40:32Z
 
 [Term]
@@ -41009,14 +41026,14 @@ def: "The plant epidermis cell is a group of cells that covers plants leaves, fl
 synonym: "epidermal cell" RELATED []
 synonym: "plant epidermis cell" RELATED []
 relationship: part_of BTO:0000116 ! plant epidermis
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2013-11-05T10:09:05Z
 
 [Term]
 id: BTO:0005523
 name: culture condition:anaerobic and sulfate-thiosulfate-lactate-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2013-11-05T10:20:03Z
 
 [Term]
@@ -41026,7 +41043,7 @@ def: "One of the two divisions of a bilabiate corolla or calyx, as in the snapdr
 synonym: "lip" RELATED []
 relationship: part_of BTO:0000163 ! corolla
 relationship: part_of BTO:0000169 ! calyx
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2013-11-06T09:57:19Z
 
 [Term]
@@ -41034,7 +41051,7 @@ id: BTO:0005525
 name: plant primordium
 def: "A cell or organ in its initial stage of development." [Plant_Anatomy_Glossary:http\://www.uri.edu/cels/bio/plant_anatomy/glossary.html]
 relationship: part_of BTO:0001461 ! whole plant
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2013-11-06T10:48:14Z
 
 [Term]
@@ -41042,7 +41059,7 @@ id: BTO:0005526
 name: axillary bud primordium
 def: "It arises in the axil of a leaf primordium." [Plant_Anatomy_Glossary:http\://www.uri.edu/cels/bio/plant_anatomy/glossary.html]
 relationship: part_of BTO:0004103 ! leaf primordium
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2013-11-06T10:53:30Z
 
 [Term]
@@ -41050,7 +41067,7 @@ id: BTO:0005527
 name: lateral root primordium
 def: "It arises in the pericycle." [Plant_Anatomy_Glossary:http\://www.uri.edu/cels/bio/plant_anatomy/glossary.html]
 is_a: BTO:0004791 ! root primordium
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2013-11-06T10:55:02Z
 
 [Term]
@@ -41058,7 +41075,7 @@ id: BTO:0005528
 name: plant secretory cell
 def: "Plant secretory cells are derived from parenchyma cells and may function on their own or as a tissue. Examples: oils in citrus, pine resin, latex, opium, nectar, perfumes and plant hormones." [Biology-Online_Dictionary:http\://www.biology-online.org/dictionary/]
 relationship: part_of BTO:0001461 ! whole plant
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2013-11-06T11:02:44Z
 
 [Term]
@@ -41067,7 +41084,7 @@ name: plant hair
 def: "A common type of trichome is a hair. Plant hairs may be unicellular or multicellular, branched or unbranched. Multicellular hairs may have one or several layers of cells. Branched hairs can be dendritic (tree-like), tufted, or stellate (star-shaped)." [Wikipedia:The_Free_Encyclopedia]
 synonym: "hair" RELATED []
 is_a: BTO:0001395 ! trichome
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2013-11-06T11:13:50Z
 
 [Term]
@@ -41076,7 +41093,7 @@ name: plant glandular hair
 def: "Any of the various types of hairs may be glandular." [Wikipedia:The_Free_Encyclopedia]
 synonym: "glandular hair" RELATED []
 is_a: BTO:0005529 ! plant hair
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2013-11-06T11:15:41Z
 
 [Term]
@@ -41087,7 +41104,7 @@ synonym: "peltate hair" RELATED []
 synonym: "plant peltate hair" RELATED []
 synonym: "scale" RELATED []
 is_a: BTO:0001395 ! trichome
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2013-11-06T11:17:29Z
 
 [Term]
@@ -41097,7 +41114,7 @@ def: "The initial cell formed when two gamete cells are joined by means of sexua
 synonym: "zygote" RELATED []
 is_a: BTO:0001233 ! plant embryo
 relationship: bearer_of BTO:0003375 ! archegonium
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2013-11-06T13:45:06Z
 
 [Term]
@@ -41106,7 +41123,7 @@ name: fungal primordium
 def: "A mushroom develops from a nodule, or pinhead, less than two millimeters in diameter, called a primordium, which is typically found on or near the surface of the substrate. It is formed within the mycelium, the mass of threadlike hyphae that make up the fungus. The primordium enlarges into a roundish structure of interwoven hyphae roughly resembling an egg, called a button." [Wikipedia:The_Free_Encyclopedia]
 synonym: "primordium" RELATED []
 relationship: part_of BTO:0001494 ! fungus
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2013-11-07T08:49:53Z
 
 [Term]
@@ -41114,7 +41131,7 @@ id: BTO:0005534
 name: arcuate nucleus
 def: "Any of various specialized groups of nerve cells in the medulla oblongata, thalamus, or hypothalamus of the brain." [The_American_Heritage_Dictionary_of_the_English_Language:Fourth_Edition_copyright_2000]
 is_a: BTO:0000938 ! neuron
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-02-20T10:03:18Z
 
 [Term]
@@ -41122,49 +41139,49 @@ id: BTO:0005535
 name: culture condition:CD56+ cell
 def: "Normal cells that stain positively for CD56 include NK cells, activated T cells, the brain and cerebellum, and neuroendocrine tissues. Tumors that are CD56-positive are myeloma, myeloid leukemia, neuroendocrine tumors, Wilms tumor, neuroblastoma, NK/T cell lymphomas, pancreatic acinar cell carcinoma, pheochromocytoma, paraganglioma, small cell lung carcinoma, and the Ewings Sarcoma Family of Tumors." [The_Free_Dictionary_by_Farlex:http\://encyclopedia.thefreedictionary.com/]
 is_a: BTO:0002008 ! culture condition:antigen-presenting cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-02-20T10:10:43Z
 
 [Term]
 id: BTO:0005536
 name: culture condition:copper-containing medium-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-02-21T11:49:10Z
 
 [Term]
 id: BTO:0005537
 name: culture condition:beta-phenylethylamine-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-02-20T12:10:42Z
 
 [Term]
 id: BTO:0005538
 name: culture condition:copper-depleted medium-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-02-21T11:50:08Z
 
 [Term]
 id: BTO:0005539
 name: culture condition:cysteate-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-02-21T11:50:59Z
 
 [Term]
 id: BTO:0005540
 name: culture condition:dimethylsulfone-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-02-21T11:52:19Z
 
 [Term]
 id: BTO:0005541
 name: culture condition:methylsulfone-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-02-21T11:53:08Z
 
 [Term]
@@ -41172,14 +41189,14 @@ id: BTO:0005542
 name: inflorescence primordium
 def: "An inflorescence in its earliest recognizable stage of development." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0005525 ! plant primordium
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-02-21T16:20:20Z
 
 [Term]
 id: BTO:0005543
 name: uterine epithelial cell
 relationship: part_of BTO:0003082 ! uterine epithelium
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-02-21T16:34:05Z
 
 [Term]
@@ -41187,7 +41204,7 @@ id: BTO:0005544
 name: gastrointestinal adenocarcinoma cell
 is_a: BTO:0000604 ! adenocarcinoma cell
 is_a: BTO:0001533 ! gastrointestinal cancer cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-02-21T16:39:42Z
 
 [Term]
@@ -41195,14 +41212,14 @@ id: BTO:0005545
 name: renal epithelial cell
 synonym: "kidney epithelial cell" RELATED []
 relationship: part_of BTO:0000059 ! renal epithelium
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-02-21T16:49:05Z
 
 [Term]
 id: BTO:0005546
 name: tuber meristem
 relationship: part_of BTO:0001400 ! tuber
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-02-25T16:18:22Z
 
 [Term]
@@ -41213,7 +41230,7 @@ synonym: "para-HVC" RELATED []
 synonym: "paraHVC" RELATED []
 synonym: "pHVC" RELATED []
 relationship: part_of BTO:0003389 ! nidopallium
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-02-25T16:24:06Z
 
 [Term]
@@ -41224,7 +41241,7 @@ synonym: "293ET cell" RELATED []
 synonym: "HEK293 EBNA T cell" RELATED []
 synonym: "HEK293ET cell" RELATED []
 relationship: develops_from BTO:0000007 ! HEK-293 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-02-26T13:30:16Z
 
 [Term]
@@ -41233,7 +41250,7 @@ name: NIH-3T3-ras cell
 def: "Murine embryonal fibroblast cell line, transfected with the H-ras-oncogene." [CLS-Cell_Lines_Service:http\://www.cell-lines-service.de/]
 synonym: "3T3-ras cell" RELATED []
 relationship: develops_from BTO:0000944 ! NIH-3T3 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-02-26T13:42:17Z
 
 [Term]
@@ -41241,7 +41258,7 @@ id: BTO:0005550
 name: 8505C cell
 def: "Established from undifferentiated thyroid carcinomas of a 78 year old female patient." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 is_a: BTO:0003209 ! anaplastic thyroid cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-02-26T13:46:25Z
 
 [Term]
@@ -41250,7 +41267,7 @@ name: abdominal aorta aneurysm disease specific cell type
 def: "Abdominal aortic aneurysm is a localized dilatation of the abdominal aorta exceeding the normal diameter by more than 50 percent, and is the most common form of aortic aneurysm. Approximately 90 percent of abdominal aortic aneurysms occur infrarenally, below the kidneys, but they can also occur pararenally, at the level of the kidneys, or suprarenally, above the kidneys." [Wikipedia:The_Free_Encyclopedia]
 synonym: "AAA disease specific cell type" RELATED []
 relationship: develops_from BTO:0002976 ! abdominal aorta
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-02-26T13:55:11Z
 
 [Term]
@@ -41258,7 +41275,7 @@ id: BTO:0005552
 name: vertebral endplate
 def: "Vertebral end plates are the top and bottom portions of the vertebral bodies that interface with the vertebral discs. The vertebral end plate is composed of a layer of thickened cancellous bone." [Spine_Health_Glossary:http\://www.spine-health.com/glossary/]
 is_a: BTO:0000140 ! bone
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-02-26T14:51:05Z
 
 [Term]
@@ -41267,7 +41284,7 @@ name: aortic intima
 def: "The innermost tunica (layer) of the aorta. It is made up of one layer of endothelial cells and is supported by an internal elastic lamina. The endothelial cells are in direct contact with the blood flow." [Wikipedia:The_Free_Encyclopedia]
 synonym: "tunica intima of the aorta" RELATED []
 relationship: part_of BTO:0000135 ! aorta
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-02-26T15:03:31Z
 
 [Term]
@@ -41275,7 +41292,7 @@ id: BTO:0005554
 name: B7E3 cell
 def: "Mouse oral tongue squamous carcinoma cell line." [Cellular\,_Molecular\,_and_Tumor_Biology_101:Adhesion_and_Signaling_in_Cancer_Progression_Abstract_4912]
 is_a: BTO:0000786 ! tongue cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-02-26T15:13:36Z
 
 [Term]
@@ -41285,7 +41302,7 @@ def: "Normal prostatic epithelium is composed of basal and luminal cells." [PMID
 synonym: "basal prostate gland epithelium cell" RELATED []
 synonym: "basal prostatic epithelium cell" RELATED []
 relationship: part_of BTO:0002397 ! prostate gland epithelium
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-02-26T15:20:42Z
 
 [Term]
@@ -41295,7 +41312,7 @@ def: "Normal prostatic epithelium is composed of basal and luminal cells." [PMID
 synonym: "luminal prostate gland epithelium cell" RELATED []
 synonym: "luminal prostatic epithelium cell" RELATED []
 relationship: part_of BTO:0002397 ! prostate gland epithelium
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-02-26T15:21:53Z
 
 [Term]
@@ -41303,7 +41320,7 @@ id: BTO:0005557
 name: BP-ALL cell
 def: "Human B-cell precursor acute lymphoblastic leukemia cell line." [PMID:17851550]
 is_a: BTO:0002144 ! acute lymphoblastic leukemia cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-02-26T15:32:59Z
 
 [Term]
@@ -41312,7 +41329,7 @@ name: T/C-28a4 cell
 def: "Immortalized human chondrocyte cell line." [PMID:14673991]
 synonym: "T/C28a4 cell" RELATED []
 relationship: develops_from BTO:0003860 ! T/C-28a2 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-02-26T15:42:17Z
 
 [Term]
@@ -41320,7 +41337,7 @@ id: BTO:0005559
 name: Caki-dTub cell
 def: "Human renal cell carcinoma selected for resistance to 2-deoxytubercidin." [PMID:17009030]
 relationship: develops_from BTO:0003204 ! Caki-1 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-02-26T15:45:11Z
 
 [Term]
@@ -41329,7 +41346,7 @@ name: C8-MEF cell
 def: "Mouse embryonic fibroblast cell line oncogenically transformed with both E1A and ras, and containing wild-type p53." [PMID:16021178]
 synonym: "C8 cell" RELATED []
 is_a: BTO:0002572 ! MEF cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-02-26T15:50:57Z
 
 [Term]
@@ -41338,14 +41355,14 @@ name: C9-MEF cell
 def: "Mouse embryonic fibroblast cell line oncogenically transformed with both E1A and ras, and containing p53-/-." [PMID:16021178]
 synonym: "C9 cell" RELATED []
 is_a: BTO:0002572 ! MEF cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-02-26T15:53:01Z
 
 [Term]
 id: BTO:0005562
 name: cardiac microvascular endothelial cell
 is_a: BTO:0003123 ! microvascular endothelial cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-02-27T09:47:39Z
 
 [Term]
@@ -41353,7 +41370,7 @@ id: BTO:0005563
 name: dental lamina
 def: "A band of ectodermal cells growing from the epithelium of the embryonic jaws into the underlying mesenchyme and giving rise to the primordia of the enamel organs of the teeth." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 is_a: BTO:0000315 ! ectoderm
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-01T18:15:37Z
 
 [Term]
@@ -41361,7 +41378,7 @@ id: BTO:0005564
 name: EBV-B cell
 def: "Epstein Barr virus-transformed human B lymphocyte cell line." [PMID:2981918]
 is_a: BTO:0001522 ! B-lymphocyte cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-01T18:21:09Z
 
 [Term]
@@ -41370,7 +41387,7 @@ name: embryonic tracheal system
 def: "The embryonic tracheal system or the fruitfly is an epithelial tubular network established from defined sets of ectodermal precursor cells." [The_interactive_fly:http\://www.sdbonline.org/sites/fly/aimorph/trachia.htm]
 synonym: "larval tracheal system" RELATED []
 relationship: part_of BTO:0000379 ! embryo
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-01T18:31:56Z
 
 [Term]
@@ -41380,7 +41397,7 @@ def: "Epithelial lining fluid forms a thin fluid layer that covers the mucosa of
 synonym: "ELF" RELATED []
 relationship: part_of BTO:0000419 ! respiratory epithelium
 relationship: produced_by BTO:0004046 ! alveolar mucosa
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-01T18:37:06Z
 
 [Term]
@@ -41389,7 +41406,7 @@ name: esophageal adenocarcinoma cell
 def: "Adenocarcinoma originates in glandular tissue not normally present in the lining of the esophagus. Before adenocarcinoma can develop, glandular cells must replace a section of squamous cells." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 is_a: BTO:0000604 ! adenocarcinoma cell
 is_a: BTO:0001577 ! esophageal cancer cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-01T18:42:22Z
 
 [Term]
@@ -41398,7 +41415,7 @@ name: gastrointestinal mucosa
 def: "The mucous coat (membrane) lining the stomach and the intestines." [Terminology_NDI_Foundation:http\://www.ndif.org/public/terms/]
 is_a: BTO:0000886 ! mucosa
 relationship: part_of BTO:0000511 ! gastrointestinal tract
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-01T18:52:14Z
 
 [Term]
@@ -41407,7 +41424,7 @@ name: hair follicle dermal papilla cell
 synonym: "follicular dermal papilla cell" RELATED []
 is_a: BTO:0001858 ! dermal papilla
 relationship: part_of BTO:0000554 ! hair follicle
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-01T18:56:26Z
 
 [Term]
@@ -41416,7 +41433,7 @@ name: HFDPC cell
 def: "Primary Human Follicle Dermal Papilla Cells are isolated from human dermis originating from the lateral scalp. Information on donor hair and skin color is available for each lot." [PromoCell:http\://www.promocell.com/]
 synonym: "primary human follicle dermal papilla cell" RELATED []
 is_a: BTO:0005569 ! hair follicle dermal papilla cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-01T18:59:45Z
 
 [Term]
@@ -41424,7 +41441,7 @@ id: BTO:0005571
 name: HAE cell
 def: "Human airway epithelial cell line." [PMID:17239851]
 is_a: BTO:0002637 ! respiratory epithelium cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-01T19:20:50Z
 
 [Term]
@@ -41432,7 +41449,7 @@ id: BTO:0005572
 name: HCE-4 cell
 def: "Human esophageal carcinoma cell line." [PMID:2415247]
 is_a: BTO:0002817 ! esophageal cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-01T19:35:00Z
 
 [Term]
@@ -41440,7 +41457,7 @@ id: BTO:0005573
 name: HCE-6 cell
 def: "Human esophageal carcinoma cell line." [PMID:2415247]
 is_a: BTO:0002817 ! esophageal cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-01T19:35:43Z
 
 [Term]
@@ -41449,7 +41466,7 @@ name: ileum smooth muscle
 def: "The smooth muscle of the ileums walls is thinner than the walls of other parts of the intestines, and its peristaltic contractions are slower." [Wikipedia:The_Free_Encyclopedia]
 synonym: "ileal smooth muscle" RELATED []
 relationship: part_of BTO:0000620 ! ileum
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-02T20:41:43Z
 
 [Term]
@@ -41457,7 +41474,7 @@ id: BTO:0005575
 name: ileum smooth muscle cell
 synonym: "ileal smooth muscle cell" RELATED []
 relationship: part_of BTO:0005574 ! ileum smooth muscle
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-02T20:43:15Z
 
 [Term]
@@ -41465,14 +41482,14 @@ id: BTO:0005576
 name: inguinal canal
 def: "A passage about one and one half inches (4 cm) long that lies parallel to and a half inch above the inguinal ligament. In the male it is the passage through which the testis descends into the scrotum and in which the spermatic cord lies - called also spermatic canal. In the female the passage is accommodating the round ligament." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/inguinal+canal]
 relationship: part_of BTO:0003358 ! groin
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-02T20:47:38Z
 
 [Term]
 id: BTO:0005577
 name: lung disease specific cell type
 relationship: develops_from BTO:0000763 ! lung
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-02T21:08:31Z
 
 [Term]
@@ -41481,7 +41498,7 @@ name: lymphangioleiomyomatosis disease specific cell type
 def: "Lymphangioleiomyomatosis is a rare lung disease that results in a proliferation of disorderly smooth muscle growth (leiomyoma) throughout the lungs, in the bronchioles, alveolar septa, perivascular spaces, and lymphatics, resulting in the obstruction of small airways (leading to pulmonary cyst formation and pneumothorax) and lymphatics (leading to chylous pleural effusion)." [Wikipedia:The_Free_Encyclopedia]
 synonym: "LAM cell" RELATED []
 is_a: BTO:0005577 ! lung disease specific cell type
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-02T21:08:53Z
 
 [Term]
@@ -41491,7 +41508,7 @@ def: "Acute myelogenous leukemia in which the predominating cell is so immature 
 synonym: "AUL cell" RELATED []
 synonym: "blast cell leukemia cell" RELATED []
 is_a: BTO:0001545 ! acute myeloid leukemia cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-03T19:26:11Z
 
 [Term]
@@ -41500,7 +41517,7 @@ name: WDNET cell
 def: "Well-differentiated neuroendocrine tumor cell." [PMID:16517981]
 synonym: "well-differentiated neuroendocrine tumor cell" RELATED []
 is_a: BTO:0001407 ! neuroendocrine tumor cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-05T10:17:12Z
 
 [Term]
@@ -41508,7 +41525,7 @@ id: BTO:0005581
 name: vestibular sensory epithelium
 def: "The vestibular sensory epithelium is located on the maculae of the saccule and utricle and the cristae of the semicircular canals. The sensory cells are surrounded by supporting cells. Therefore, they do not come into direct contact with the bony base of the cristae." [Medscape:http\://emedicine.medscape.com/]
 relationship: part_of BTO:0003382 ! inner ear vestibulum
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-05T11:05:06Z
 
 [Term]
@@ -41517,21 +41534,21 @@ name: Ra-2 cell
 def: "Mouse microglial cell line." [PMID:15792809]
 synonym: "Ra2 cell" RELATED []
 is_a: BTO:0003349 ! microglial cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-05T11:18:50Z
 
 [Term]
 id: BTO:0005583
 name: promonocytic leukemia cell line
 is_a: BTO:0000737 ! leukemia cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-05T19:34:41Z
 
 [Term]
 id: BTO:0005584
 name: promonocytic leukemia cell
 is_a: BTO:0001271 ! leukemia cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-05T19:36:32Z
 
 [Term]
@@ -41540,21 +41557,21 @@ name: prepolar cell
 def: "During Drosophila oogenesis somatic stem cells give rise to precursor follicle cells and about 16 of them invade between adjoining cysts, cease division, and become pre-polar cells, which ultimately become polar cells and stalk cells." [Developmental_Dynamics:http\://onlinelibrary.wiley.com/doi/10.1002/dvdy.21625/full]
 synonym: "pre-polar cell" RELATED []
 is_a: BTO:0000535 ! germ cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-05T19:50:27Z
 
 [Term]
 id: BTO:0005586
 name: polar cell
 relationship: develops_from BTO:0005585 ! prepolar cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-05T19:59:16Z
 
 [Term]
 id: BTO:0005587
 name: stalk cell
 relationship: develops_from BTO:0005585 ! prepolar cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-05T19:59:34Z
 
 [Term]
@@ -41565,7 +41582,7 @@ synonym: "intercalary oviduct cell" RELATED []
 synonym: "non-ciliated oviduct cell" RELATED []
 synonym: "secretory oviduct cell" RELATED []
 relationship: part_of BTO:0002402 ! oviduct epithelium
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-06T09:37:10Z
 
 [Term]
@@ -41574,7 +41591,7 @@ name: oviduct ciliated cell
 def: "A ciliated columnar epithelium lines the lumen of the uterine tube, where currents generated by the cilia propel the egg cell toward the uterus." [Wikipedia:The_Free_Encyclopedia]
 synonym: "ciliated simple columnar epithelial cell" RELATED []
 relationship: part_of BTO:0002402 ! oviduct epithelium
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-06T09:41:03Z
 
 [Term]
@@ -41584,7 +41601,7 @@ synonym: "cervix adenocarcinoma cell line" RELATED []
 synonym: "uterine cervix adenocarcinoma cell line" RELATED []
 is_a: BTO:0000167 ! adenocarcinoma cell line
 is_a: BTO:0001967 ! cervical cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-06T10:42:29Z
 
 [Term]
@@ -41592,7 +41609,7 @@ id: BTO:0005591
 name: mesolimbic dopaminergic system
 def: "The mesolimbic dopaminergic system includes the ventral tegmental area that project mainly to the nucleus accumbens as well as the olfactory tubercle innervating the septum, amygdala and hippocampus." [PMID:20925949]
 relationship: part_of BTO:0005593 ! mesocorticolimbic dopaminergic system
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-06T10:58:16Z
 
 [Term]
@@ -41600,7 +41617,7 @@ id: BTO:0005592
 name: mesocortical dopaminergic system
 def: "The mesocortical dopaminergic system which includes the ventral tegmental area, extends its fibers in the prefrontal, cingulate and perirhinal cortex. Because of the overlap between these two systems they are often collectively referred to as the mesocorticolimbic system." [PMID:20925949]
 relationship: part_of BTO:0005593 ! mesocorticolimbic dopaminergic system
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-06T11:02:54Z
 
 [Term]
@@ -41609,7 +41626,7 @@ name: mesocorticolimbic dopaminergic system
 def: "Because of the overlap between the mesocortical and the mesolimbic dopaminergic systems, they are often collectively referred to as the mesocorticolimbic system." [PMID:20925949]
 synonym: "mesocorticolimbic dopamine system" RELATED []
 is_a: BTO:0003954 ! dopaminergic system
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-06T11:03:41Z
 
 [Term]
@@ -41618,7 +41635,7 @@ name: metastatic renal cell carcinoma cell
 def: "Metastatic renal cell carcinoma is the spread of the primary renal cell carcinoma from the kidney to other organs." [Wikipedia:The_Free_Encyclopedia]
 synonym: "mRCC cell" RELATED []
 is_a: BTO:0000037 ! renal cell carcinoma cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-06T11:09:55Z
 
 [Term]
@@ -41626,7 +41643,7 @@ id: BTO:0005595
 name: microplantlet suspension culture
 def: "A phototrophic microplantlet culture, consisting of regenerated shoot tissues in liquid suspension, established from red algae and cultivated in a stirred tank photobioreactor." [PMID:12675582]
 is_a: BTO:0003916 ! plant culture
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-06T11:13:31Z
 
 [Term]
@@ -41634,7 +41651,7 @@ id: BTO:0005596
 name: epitheloid cell
 def: "A nonepithelial cell, especially one derived from a macrophage, having characteristics resembling those of an epithelial cell, often found in granulomas associated with tuberculosis." [The_American_Heritage_Medical_Dictionary:Copyright_2007]
 relationship: develops_from BTO:0000801 ! macrophage
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-07T09:27:20Z
 
 [Term]
@@ -41643,7 +41660,7 @@ name: Langhans giant cell
 def: "Langhans giant cells are large cells found in granulomatous conditions. They are formed by the fusion of epithelioid cells (macrophages), and contain nuclei arranged in a horseshoe-shaped pattern in the cell periphery. Although traditionally their presence was associated with tuberculosis, they are not specific for tuberculosis or even for mycobacterial disease. In fact, they are found in nearly every form of granulomatous disease, regardless of etiology." [Wikipedia:The_Free_Encyclopedia]
 synonym: "Pirogov-Langhans cell" RELATED []
 is_a: BTO:0000801 ! macrophage
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-07T09:46:16Z
 
 [Term]
@@ -41652,7 +41669,7 @@ name: peritubular contractile cell
 def: "Any of various flattened cells that surround seminiferous tubules." [The_American_Heritage_Medical_Dictionary:Copyright_2007]
 synonym: "myoid cell" RELATED []
 relationship: part_of BTO:0001235 ! seminiferous tubule
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-07T10:08:57Z
 
 [Term]
@@ -41661,7 +41678,7 @@ name: periodontal ligament cell
 def: "Periodontal ligament cells are believed to play an important role in periodontal regeneration. That is, they may differentiate into specific cells which make cementum, bone, and attachment apparatus." [PMID:15974856]
 synonym: "PDL cell" RELATED []
 relationship: part_of BTO:0001020 ! periodontal ligament
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-07T11:40:26Z
 
 [Term]
@@ -41671,7 +41688,7 @@ def: "The outer nuclear layer is one of the layers of the vertebrate retina, the
 synonym: "external nuclear layer" RELATED []
 synonym: "layer of outer granules" RELATED []
 relationship: part_of BTO:0001175 ! retina
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-07T11:45:37Z
 
 [Term]
@@ -41679,7 +41696,7 @@ id: BTO:0005601
 name: paracentral lobule
 def: "The term paracentral lobule refers to the junction of the precentral gyrus and postcentral gyrus on the medial surface of the cerebral cortex. It lies across the boundary between the frontal lobe and the parietal lobe." [University_of_Washington_BrainInfo:http\://braininfo.rprc.washington.edu/centraldirectory.aspx?type=a&ID=404]
 relationship: part_of BTO:0000233 ! cerebral cortex
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-07T11:51:22Z
 
 [Term]
@@ -41688,7 +41705,7 @@ name: anterior paracentral gyrus
 def: "The anterior portion of the paracentral lobule, the medial continuation of the primary somatomotor cortex (precentral gyrus) in which the thigh, leg, and foot are represented." [Medical_Dictionary:http\://www.medilexicon.com/]
 synonym: "gyrus paracentralis anterior" RELATED []
 relationship: part_of BTO:0005601 ! paracentral lobule
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-07T11:54:52Z
 
 [Term]
@@ -41697,14 +41714,14 @@ name: posterior paracentral gyrus
 def: "The posterior part of the paracentral lobule; the medial continuation of the primary somatosensory cortex (postcentral gyrus) in which sensory input from the thigh, leg, and foot are represented." [Medical_Dictionary:http\://www.medilexicon.com/]
 synonym: "gyrus paracentralis posterior" RELATED []
 relationship: part_of BTO:0005601 ! paracentral lobule
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-07T11:57:37Z
 
 [Term]
 id: BTO:0005604
 name: pharate pupal cuticle
 relationship: part_of BTO:0001046 ! pharate pupa
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-09T15:31:47Z
 
 [Term]
@@ -41713,7 +41730,7 @@ name: pulmonary neuroendocrine tumor cell
 def: "Neuroendocrine tumors (NETs) are neoplasms that arise from cells of the endocrine (hormonal) and nervous systems. Many are benign, while some are malignant. They most commonly occur in the intestine, where they are often called carcinoid tumors, but they are also found in the lung and the rest of the body." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0000551 ! lung cancer cell
 is_a: BTO:0001407 ! neuroendocrine tumor cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-09T15:37:19Z
 
 [Term]
@@ -41721,7 +41738,7 @@ id: BTO:0005606
 name: precerebellar system
 def: "The precerebellar system provides the principal input to the cerebellum and is essential for coordinated motor activity. This ventral brainstem system in the mouse derives from dorsally located rhombic neuroepithelium." [PMID:17150414]
 is_a: BTO:0000146 ! brain stem
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-09T15:49:00Z
 
 [Term]
@@ -41733,21 +41750,21 @@ synonym: "gamma-delta T-cell" RELATED []
 synonym: "gamma/delta T-cell" RELATED []
 synonym: "TCR gamma delta cell" RELATED []
 is_a: BTO:0000782 ! T-lymphocyte
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-09T15:57:07Z
 
 [Term]
 id: BTO:0005608
 name: pupal wing
 is_a: BTO:0001143 ! pupa
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-09T16:04:27Z
 
 [Term]
 id: BTO:0005609
 name: pupal wing cuticle
 relationship: part_of BTO:0005608 ! pupal wing
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-09T16:06:17Z
 
 [Term]
@@ -41756,7 +41773,7 @@ name: ventricular aneurysm disease specific cell type
 def: "An aneurysm is the outward swelling, or ballooning, of a blood vessel at a weak spot in the wall of the blood vessel. In the case of ventricular aneurysm, the aneurysm occurs in the wall of the heart at the spot where the myocardial infarction occurred. A scar usually forms in the area of the dead muscle tissue, and may eventually calcify. Ventricular aneurysms generally do not rupture. The left ventricle is involved in most cases of ventricular aneurysm." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 synonym: "ventricular aneurysm tissue" RELATED []
 relationship: disease_causes_dysfunction_of BTO:0000862 ! heart ventricle
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-09T16:10:25Z
 
 [Term]
@@ -41766,7 +41783,7 @@ def: "Highly metastatic murine melanoma overexpressing PKC delta BL6 (BL6T) and 
 synonym: "BL-6T cell" RELATED []
 synonym: "BL6T cell" RELATED []
 relationship: develops_from BTO:0002014 ! B16-F10 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-11T17:24:24Z
 
 [Term]
@@ -41776,7 +41793,7 @@ def: "Highly metastatic murine melanoma overexpressing PKC delta BL6 (BL6T) and 
 comment: Seems to be a synonym of B16-BL6 cell.
 synonym: "BL6 cell" RELATED []
 is_obsolete: true
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-11T17:26:29Z
 
 [Term]
@@ -41785,7 +41802,7 @@ name: BMC-2 cell
 def: "Mouse macrophage cell line." [PMID:21873432]
 synonym: "BMC2 cell" RELATED []
 is_a: BTO:0002278 ! macrophage cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-11T17:31:21Z
 
 [Term]
@@ -41793,7 +41810,7 @@ id: BTO:0005614
 name: BMA cell
 def: "Mouse macrophage cell line." [PMID:21873432]
 is_a: BTO:0002278 ! macrophage cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-11T17:34:52Z
 
 [Term]
@@ -41802,7 +41819,7 @@ name: KM-20C cell
 def: "Human primary colon cancer cell line." [PMID:2492206]
 synonym: "KM20C cell" RELATED []
 is_a: BTO:0001616 ! colorectal cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-11T17:49:08Z
 
 [Term]
@@ -41810,7 +41827,7 @@ id: BTO:0005616
 name: Asp-86 cell
 def: "Cell line of Asparagus offcinalis L.." [PMID:10734215]
 is_a: BTO:0001971 ! plant cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-13T11:16:56Z
 
 [Term]
@@ -41818,7 +41835,7 @@ id: BTO:0005617
 name: Sly-1 cell
 def: "Cell line of Lycopersicon esculentum Mill.." [PMID:10734215]
 is_a: BTO:0001971 ! plant cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-13T11:17:38Z
 
 [Term]
@@ -41826,7 +41843,7 @@ id: BTO:0005618
 name: subpharyngeal region
 def: "Region beneath the pharynx." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 relationship: part_of BTO:0000058 ! alimentary canal
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-03-13T11:38:57Z
 
 [Term]
@@ -41834,7 +41851,7 @@ id: BTO:0005619
 name: cladode
 def: "A flattened organ arising from the stem of a plant. These often replace the leaves in photosynthetic function, as leaves in such plants (for example asparagus, butchers broom) are typically reduced to scales." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0001243 ! shoot
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-01T11:03:48Z
 
 [Term]
@@ -41842,7 +41859,7 @@ id: BTO:0005620
 name: CCE-24 cell
 def: "Mouse embryonic stem cell line." [PMID:20506347]
 is_a: BTO:0003560 ! CCE cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-02T10:04:08Z
 
 [Term]
@@ -41853,7 +41870,7 @@ synonym: "Hep G2.2.15 cell" RELATED []
 synonym: "Hep-G2.2.15 cell" RELATED []
 synonym: "HepG2.2.15 cell" RELATED []
 relationship: develops_from BTO:0000599 ! Hep-G2 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-02T10:11:00Z
 
 [Term]
@@ -41863,14 +41880,14 @@ def: "Suspension-cultured Digitalis lanata cells." [PMID:17265224]
 synonym: "K 3 OHD cell" RELATED []
 synonym: "K3 OHD cell" RELATED []
 is_a: BTO:0001971 ! plant cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-02T10:22:52Z
 
 [Term]
 id: BTO:0005623
 name: neuroepithelial cell line
 relationship: develops_from BTO:0004301 ! neuroepithelial cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-02T10:28:05Z
 
 [Term]
@@ -41878,7 +41895,7 @@ id: BTO:0005624
 name: NE-4C cell
 def: "The neuroepithelial cell line was established from the cerebral vesicles of 9-day-old mouse embryos lacking the functional p53 genes." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 is_a: BTO:0005623 ! neuroepithelial cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-02T10:28:24Z
 
 [Term]
@@ -41886,7 +41903,7 @@ id: BTO:0005625
 name: NE-GFP-4C cell
 def: "The neuroepithelial cell line NE-GFP-4C was established from the cerebral vesicles of 9-day-old mouse embryos lacking the functional p53 genes." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 relationship: develops_from BTO:0005624 ! NE-4C cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-02T10:28:55Z
 
 [Term]
@@ -41894,7 +41911,7 @@ id: BTO:0005626
 name: osteoarticular cell
 def: "Cell pertaining to or affecting bones and joints." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 relationship: part_of BTO:0000421 ! connective tissue
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-02T10:32:39Z
 
 [Term]
@@ -41902,7 +41919,7 @@ id: BTO:0005627
 name: parametrium
 def: "The connective tissue and fat adjacent to the uterus." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionaryparametrium]
 is_a: BTO:0000421 ! connective tissue
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-02T10:38:47Z
 
 [Term]
@@ -41913,7 +41930,7 @@ synonym: "parametrial adipose tissue" RELATED []
 synonym: "parametrial fat" RELATED []
 is_a: BTO:0000444 ! fat pad
 relationship: part_of BTO:0005627 ! parametrium
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-02T10:40:14Z
 
 [Term]
@@ -41925,7 +41942,7 @@ is_a: BTO:0002606 ! glial cell
 relationship: part_of BTO:0001028 ! peripheral nervous system
 relationship: part_of BTO:0001256 ! parasympathetic ganglion
 relationship: part_of BTO:0001333 ! sympathetic ganglion
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-02T10:48:58Z
 
 [Term]
@@ -41933,7 +41950,7 @@ id: BTO:0005630
 name: sensory ganglion
 def: "The ganglion on the roots of the cranial nerves, containing the cell bodies of sensory neurons; The spinal ganglion." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 is_a: BTO:0000497 ! ganglion
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-02T10:52:35Z
 
 [Term]
@@ -41942,7 +41959,7 @@ name: G3/F11 cell
 def: "Mouse hybridoma cell line containing the human aspartyl (asparaginyl) beta-hydroxylase." [PMID:21466288]
 synonym: "hybridoma G3/F11 cell" RELATED []
 is_a: BTO:0001926 ! hybridoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-03T09:20:26Z
 
 [Term]
@@ -41950,7 +41967,7 @@ id: BTO:0005632
 name: sympodium
 def: "The main axis of growth in the grapevine and similar plants: a lateral branch that arises from just behind the apex of the main stem, which ceases to grow, and continues growing in the same direction as the main stem." [Dictionary:http\://www.thefreedictionary.com/]
 is_a: BTO:0001300 ! stem
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-02T11:02:28Z
 
 [Term]
@@ -41958,7 +41975,7 @@ id: BTO:0005633
 name: monopodium
 def: "A main axis of a plant, such as the trunk of a spruce, that maintains a single line of growth, giving off lateral branches." [The_American_Heritage_Dictionary_of_the_English_Language:Fourth_Edition_copyright_2000]
 is_a: BTO:0001300 ! stem
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-02T11:05:17Z
 
 [Term]
@@ -41966,21 +41983,21 @@ id: BTO:0005634
 name: TIG-7 cell
 def: "Cell line TIG-7 derived from human male fetal lung." [PMID:\:8305734]
 is_a: BTO:0000161 ! lung fibroblast cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-02T11:10:23Z
 
 [Term]
 id: BTO:0005635
 name: culture condition:avicel-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-02T11:21:26Z
 
 [Term]
 id: BTO:0005636
 name: culture condition:wheat bran-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-02T11:22:35Z
 
 [Term]
@@ -41989,7 +42006,7 @@ name: Idiopathic pulmonary fibrosis disease specific cell type
 def: "Idiopathic pulmonary fibrosis (IPF) is a chronic interstitial lung disease of unknown etiology characterized by an accumulation of extracellular matrix, resulting in impaired pulmonary function." [PMID:17986007]
 synonym: "IPF disease specific cell type" RELATED []
 is_a: BTO:0005577 ! lung disease specific cell type
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-03T09:57:34Z
 
 [Term]
@@ -41997,7 +42014,7 @@ id: BTO:0005638
 name: LF1 cell
 def: "Primary myofibroblast cell culture isolated from an individual patient with idiopathic pulmonary fibrosis." [PMID:17986007]
 is_a: BTO:0005637 ! Idiopathic pulmonary fibrosis disease specific cell type
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-03T09:58:24Z
 
 [Term]
@@ -42005,7 +42022,7 @@ id: BTO:0005639
 name: LF2 cell
 def: "Primary myofibroblast cell culture isolated from an individual patient with idiopathic pulmonary fibrosis." [PMID:17986007]
 is_a: BTO:0005637 ! Idiopathic pulmonary fibrosis disease specific cell type
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-03T10:02:20Z
 
 [Term]
@@ -42014,7 +42031,7 @@ name: aortic adventitial fibroblast
 def: "Human Aortic Adventitial Fibroblasts (HAoAF). Primary human aortic adventitial fibroblasts (HAoAF) are isolated from human aortic adventitial tissue." [PromoCell:http\://www.promocell.com/]
 is_a: BTO:0000452 ! fibroblast
 relationship: part_of BTO:0002010 ! tunica externa vasorum
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-05T19:45:22Z
 
 [Term]
@@ -42022,91 +42039,91 @@ id: BTO:0005641
 name: awn
 def: "Any of the bristles growing from the spikelets of certain grasses, including cereals." [Dictionary:http\://www.thefreedictionary.com/]
 relationship: part_of BTO:0002119 ! spikelet
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-05T19:54:40Z
 
 [Term]
 id: BTO:0005642
 name: culture condition:3-hydroxyphenylacetate-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-05T19:58:54Z
 
 [Term]
 id: BTO:0005643
 name: culture condition:acetate/raffinose-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-05T20:03:14Z
 
 [Term]
 id: BTO:0005644
 name: culture condition:D-galacturonate-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-05T20:03:58Z
 
 [Term]
 id: BTO:0005645
 name: culture condition:D-glucosaminate-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-05T20:05:23Z
 
 [Term]
 id: BTO:0005646
 name: culture condition:D-mannitol-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-05T20:06:02Z
 
 [Term]
 id: BTO:0005647
 name: culture condition:glycine betaine-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-05T20:06:41Z
 
 [Term]
 id: BTO:0005648
 name: culture condition:isoprimeverose-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-05T20:07:51Z
 
 [Term]
 id: BTO:0005649
 name: culture condition:isopropanol-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-05T20:08:39Z
 
 [Term]
 id: BTO:0005650
 name: culture condition:N-acetyltaurine-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-05T20:09:15Z
 
 [Term]
 id: BTO:0005651
 name: culture condition:scyllo-inositol-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-05T20:11:31Z
 
 [Term]
 id: BTO:0005652
 name: culture condition:tetradecyltrimethylammonium bromide-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-05T20:12:21Z
 
 [Term]
 id: BTO:0005653
 name: culture condition:tetrathionate-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-05T20:12:50Z
 
 [Term]
@@ -42115,7 +42132,7 @@ name: nerve ring
 def: "A ring of nervous tissue, especially a ring of concentrated nervous tissue about the pharynx of various invertebrate animals." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/nerve_ring]
 is_a: BTO:0000938 ! neuron
 is_a: BTO:0001262 ! soft body part
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-08T12:07:39Z
 
 [Term]
@@ -42124,7 +42141,7 @@ name: Th17 cell
 def: "A subset of T helper cells producing interleukin 17. They are developmentally distinct from Th1 and Th2 cells. They create inflammation and tissue injury in autoimmune disease such as multiple sclerosis (which was previously thought to be caused by Th1 cells), psoriasis, autoimmune uveitis, juvenile diabetes, rheumatoid arthritis, and Crohns disease." [Wikipedia:The_Free_Encyclopedia]
 synonym: "T helper 17 cell" RELATED []
 is_a: BTO:0002417 ! helper T-lymphocyte
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-08T12:13:58Z
 
 [Term]
@@ -42134,7 +42151,7 @@ def: "Endometriotic epithelial cell line." [PMID:23183084]
 synonym: "Z12 cell" RELATED []
 synonym: "Z12 Eo cell" RELATED []
 is_a: BTO:0001996 ! endometrial cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-08T12:23:11Z
 
 [Term]
@@ -42142,7 +42159,7 @@ id: BTO:0005657
 name: adrenal cortex steroidogenic cell
 def: "A steroidogenic cell is involved in the formation of steroids, as by the adrenal cortex, testes, and ovaries." [Dictionary:http\://www.thefreedictionary.com/]
 relationship: part_of BTO:0000045 ! adrenal cortex
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-09T10:06:04Z
 
 [Term]
@@ -42150,7 +42167,7 @@ id: BTO:0005658
 name: testis steroidogenic cell
 def: "A steroidogenic cell is involved in the formation of steroids, as by the adrenal cortex, testes, and ovaries." [Dictionary:http\://www.thefreedictionary.com/]
 relationship: part_of BTO:0001363 ! testis
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-09T10:11:25Z
 
 [Term]
@@ -42159,15 +42176,15 @@ name: ovarian steroidogenic cell
 def: "A steroidogenic cell is involved in the formation of steroids, as by the adrenal cortex, testes, and ovaries." [Dictionary:http\://www.thefreedictionary.com/]
 synonym: "ovary steroidogenic cell" RELATED []
 relationship: part_of BTO:0000975 ! ovary
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-09T10:11:35Z
 
 [Term]
 id: BTO:0005660
 name: corolla tube
-def: "The tubular part of the corolla." [curators:mgr]
+def: "The tubular part of the corolla." []
 relationship: part_of BTO:0000163 ! corolla
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-09T10:27:45Z
 
 [Term]
@@ -42175,23 +42192,23 @@ id: BTO:0005661
 name: buccal mass
 def: "The mouthparts in mollusks other than bivalves and the muscles by which they are operated and with which they generally form a more or less compact mass." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/buccal_mass]
 is_a: BTO:0001262 ! soft body part
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-09T10:48:04Z
 
 [Term]
 id: BTO:0005662
 name: buccal muscle
-def: "The muscle of the buccal mass." [curators:mgr]
+def: "The muscle of the buccal mass." []
 synonym: "muscle of the buccal mass" RELATED []
 relationship: part_of BTO:0005661 ! buccal mass
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-04-09T10:49:07Z
 
 [Term]
 id: BTO:0005663
 name: culture condition:autotrophically-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-09-02T09:26:00Z
 
 [Term]
@@ -42201,7 +42218,7 @@ def: "A moderately differentiated human colon cancer cell line." [PMID:24176760]
 synonym: "Coga-1A cell" RELATED []
 synonym: "Coga1A cell" RELATED []
 is_a: BTO:0000797 ! colonic cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-09-05T08:00:59Z
 
 [Term]
@@ -42211,7 +42228,7 @@ def: "Human colon cancer cell line." [PMID:22940288]
 synonym: "Coga-13 cell" RELATED []
 synonym: "Coga13 cell" RELATED []
 is_a: BTO:0000797 ! colonic cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-09-05T08:06:23Z
 
 [Term]
@@ -42220,7 +42237,7 @@ name: Caco-2/AQ cell
 def: "A differentiated human colon cancer cell line." [PMID:24176760]
 synonym: "Caco2/AQ cell" RELATED []
 relationship: develops_from BTO:0000195 ! CACO-2 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-09-05T08:09:10Z
 
 [Term]
@@ -42230,7 +42247,7 @@ def: "Human small cell lung cancer cell line, established from a 69 years old ca
 synonym: "H-889 cell" RELATED []
 synonym: "H889 cell" RELATED []
 is_a: BTO:0002206 ! small cell lung cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-09-05T08:24:17Z
 
 [Term]
@@ -42240,7 +42257,7 @@ def: "Human small cell lung cancer cell line, established from a 54 years old ca
 synonym: "DMS 53 cell" RELATED []
 synonym: "DMS53 cell" RELATED []
 is_a: BTO:0002206 ! small cell lung cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-09-05T08:28:47Z
 
 [Term]
@@ -42249,7 +42266,7 @@ name: NCI-H295A cell
 def: "NCI-H295A cells are an adherent subline of human adrenocortical carcinoma NCI-H295 cells that express all adrenal steroidogenic enzymes in a physiologically appropriate, hormonal responsive fashion." [PMID:23836902]
 synonym: "H295A cell" RELATED []
 relationship: develops_from BTO:0002587 ! NCI-H295 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-09-05T08:38:16Z
 
 [Term]
@@ -42257,7 +42274,7 @@ id: BTO:0005670
 name: C-20/A4 cell
 def: "Human chondrocyte cell line, derived from juvenile costal chondrocytes by immortalization with origin-defective simian virus 40 large T antigen." [PMID:15604530]
 is_a: BTO:0003858 ! chondrocyte cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-09-05T10:12:22Z
 
 [Term]
@@ -42265,7 +42282,7 @@ id: BTO:0005671
 name: KGN cell
 def: "A steroidogenic human ovarian granulosa-like tumor cell line, from a patient with invasive ovarian granulosa cell carcinoma." [PMID:11145608]
 is_a: BTO:0002285 ! granulosa cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-09-05T10:19:11Z
 
 [Term]
@@ -42277,7 +42294,7 @@ synonym: "C42 cell" RELATED []
 synonym: "LNCaP subline C4-2" RELATED []
 synonym: "LNCaP-C4-2 cell" RELATED []
 relationship: develops_from BTO:0001321 ! LNCaP cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-09-05T10:26:51Z
 
 [Term]
@@ -42288,7 +42305,7 @@ synonym: "CL-1 prostate cancer cell" RELATED []
 synonym: "CL1 cell" RELATED []
 synonym: "LNCaP-C4-2 cell" RELATED []
 relationship: develops_from BTO:0001321 ! LNCaP cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-09-05T10:30:22Z
 
 [Term]
@@ -42296,7 +42313,7 @@ id: BTO:0005674
 name: SW-60 cell
 def: "Human colorectal tumor cell line." [PMID:15806169]
 is_a: BTO:0001616 ! colorectal cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-09-05T11:01:14Z
 
 [Term]
@@ -42307,7 +42324,7 @@ synonym: "BNL 1ME A.7R.1 cell" RELATED []
 synonym: "BNL 1MEA.7R.1 cell" RELATED []
 synonym: "BNL.1ME A.7R.1 cell" RELATED []
 relationship: develops_from BTO:0002537 ! BNL CL.2 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-09-05T11:10:09Z
 
 [Term]
@@ -42318,7 +42335,7 @@ synonym: "mucosa of vagina" RELATED []
 synonym: "mucous membrane of vagina" RELATED []
 synonym: "tunica mucosa vaginae" RELATED []
 is_a: BTO:0000243 ! vagina
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-09-10T13:19:26Z
 
 [Term]
@@ -42326,7 +42343,7 @@ id: BTO:0005677
 name: BmN4-SID1 cell
 def: "Silkworm ovary-derived cell line, ectopically expressing Caenorhabditis elegans transmembrane protein SID-1, which functions as a channel for the transport of dsRNA." [PMID:24773378]
 relationship: develops_from BTO:0005690 ! BmN4 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-09-05T11:17:51Z
 
 [Term]
@@ -42335,25 +42352,25 @@ name: cervicovaginal cell
 def: "Cell of or relating to the uterine cervix and the vagina." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/cervicovaginal]
 relationship: part_of BTO:0000243 ! vagina
 relationship: part_of BTO:0001424 ! uterus
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-09-10T13:24:49Z
 
 [Term]
 id: BTO:0005679
 name: small luteal cell
-def: "Small luteal cells are derived from follicular theca cells." [curators:mgr]
+def: "Small luteal cells are derived from follicular theca cells." []
 synonym: "thecal-lutein cell" RELATED []
 is_a: BTO:0003939 ! luteal cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-09-10T13:35:57Z
 
 [Term]
 id: BTO:0005680
 name: large luteal cell
-def: "Large luteal cells are derived from follicular granulosa cells." [curators:mgr]
+def: "Large luteal cells are derived from follicular granulosa cells." []
 synonym: "granulosal-lutein cell" RELATED []
 is_a: BTO:0003939 ! luteal cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-09-10T13:38:41Z
 
 [Term]
@@ -42361,7 +42378,7 @@ id: BTO:0005681
 name: storage root
 def: "A modified root for storage of food or water, such as carrots and beets." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0001188 ! root
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-09-10T14:00:43Z
 
 [Term]
@@ -42371,7 +42388,7 @@ def: "Mouse 2B4 T hybridoma cell line." [PMID:17850179]
 synonym: "2B4 T cell" RELATED []
 synonym: "2B4-T hybridoma cell" RELATED []
 is_a: BTO:0001926 ! hybridoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-09-10T14:06:45Z
 
 [Term]
@@ -42379,7 +42396,7 @@ id: BTO:0005683
 name: VK-2/E6E7 cell
 def: "The vaginal epithelial cell line VK-2/E6E7 was derived from epithelial cells of vaginal mucosal tissue from a 32-years-old premenopausal woman undergoing anterior-posterior repair and was demonstrated to have structural and functional properties similar to those of their parental primary cells." [PMID:23153564]
 is_a: BTO:0002936 ! vaginal cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-09-12T14:22:33Z
 
 [Term]
@@ -42388,28 +42405,28 @@ name: MYP-30 cell
 def: "A pig endothelial cell line." [PMID:22564646]
 synonym: "MYP30 cell" RELATED []
 is_a: BTO:0001519 ! endothelial cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-09-12T14:42:19Z
 
 [Term]
 id: BTO:0005685
 name: culture condition:4-hydroxybutyrate-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-10-21T08:58:19Z
 
 [Term]
 id: BTO:0005686
 name: culture condition:heterotrophically-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-10-21T09:00:15Z
 
 [Term]
 id: BTO:0005687
 name: culture condition:D-tagatose-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-10-21T09:01:32Z
 
 [Term]
@@ -42419,7 +42436,7 @@ def: "The tissue that produces all aerial parts of the plant, which include the 
 synonym: "shoot meristem" RELATED []
 is_a: BTO:0000034 ! apical meristem
 relationship: part_of BTO:0001243 ! shoot
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-10-21T10:32:19Z
 
 [Term]
@@ -42427,7 +42444,7 @@ id: BTO:0005689
 name: atrioventricular node
 def: "A small mass of specialized cardiac muscle fibers, located in the wall of the right atrium of the heart, that receives heartbeat impulses from the sinoatrial node and directs them to the walls of the ventricles." [The_American_Heritage_Dictionary_of_the_English_Language:Fourth_Edition_copyright_2000]
 relationship: part_of BTO:0001703 ! right atrium
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-10-21T11:14:00Z
 
 [Term]
@@ -42435,7 +42452,7 @@ id: BTO:0005690
 name: BmN4 cell
 def: "Bombyx mori ovary-derived cultured cell line." [PMID:19460866]
 relationship: develops_from BTO:0001267 ! BmN cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-10-22T18:07:00Z
 
 [Term]
@@ -42444,7 +42461,7 @@ name: RCC-4 cell
 def: "Renal cell carcinoma cell line stably transfected with an empty expression vector, pcDNA3, conferring neomycin resistance." [European_collection_of_cell_cultures:ECACC]
 synonym: "RCC4 cell" RELATED []
 is_a: BTO:0000383 ! renal cell carcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-10-22T18:13:27Z
 
 [Term]
@@ -42452,7 +42469,7 @@ id: BTO:0005692
 name: column
 def: "A columnlike structure, especially one formed by the union of a stamen and the style in an orchid flower, or one formed by the united staminal filaments in flowers such as those of the hibiscus or mallow." [Dictionary:http\://www.thefreedictionary.com/]
 relationship: develops_from BTO:0001559 ! stamen
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2014-10-22T18:44:09Z
 
 [Term]
@@ -42461,7 +42478,7 @@ name: lateral nerve cord
 def: "A cord of nerve tissue that is formed by union of the superior and middle trunks of the brachial plexus and that forms one of the two roots of the median nerve." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/lateral_cord]
 synonym: "lateral cord" RELATED []
 is_a: BTO:0001656 ! nerve cord
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-14T10:18:09Z
 
 [Term]
@@ -42469,7 +42486,7 @@ id: BTO:0005694
 name: stem leaf
 def: "A leaf growing from the stem of a plant, as contrasted with a basal or radical leaf." [Dictionary:http\://www.thefreedictionary.com/]
 is_a: BTO:0000713 ! leaf
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-14T10:47:18Z
 
 [Term]
@@ -42477,7 +42494,7 @@ id: BTO:0005695
 name: sensorimotor area
 def: "The precentral and postcentral gyri of the cerebral cortex." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 is_a: BTO:0000233 ! cerebral cortex
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-14T10:56:29Z
 
 [Term]
@@ -42486,7 +42503,7 @@ name: amoeboid microglia
 def: "This form of microglial cell is found mainly within the perinatal white matter areas in the corpus callosum known as the Fountains of Microglia. This shape allows the microglial free movement throughout the neural tissue, which allows it to fulfill its role as a scavenger cell. Amoeboid microglia are able to phagocytose debris, but do not fulfill the same antigen-presenting and inflammatory roles as activated microglia. Amoeboid microglia are especially prevalent during the development and rewiring of the brain, when there are large amounts of extracellular debris and apoptotic cells to remove." [Wikipedia:The_Free_Encyclopedia]
 synonym: "amoeboid microglial cell" RELATED []
 is_a: BTO:0000078 ! microglia
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-14T12:32:20Z
 
 [Term]
@@ -42494,7 +42511,7 @@ id: BTO:0005697
 name: atrichoblast cell
 def: "A root epidermal cell that will not give rise to a root hair." [GeneOntology:http\://obo.cvs.sourceforge.net/viewvc/obo/obo/ontology/genomic-proteomic/gene_ontology_edit.obo]
 is_a: BTO:0005699 ! root epidermal cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-14T12:40:00Z
 
 [Term]
@@ -42502,7 +42519,7 @@ id: BTO:0005698
 name: trichoblast cell
 def: "A root epidermal cell that will give rise to a root hair." [GeneOntology:http\://obo.cvs.sourceforge.net/viewvc/obo/obo/ontology/genomic-proteomic/gene_ontology_edit.obo]
 is_a: BTO:0005699 ! root epidermal cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-14T12:44:16Z
 
 [Term]
@@ -42510,35 +42527,35 @@ id: BTO:0005699
 name: root epidermal cell
 relationship: part_of BTO:0000116 ! plant epidermis
 relationship: part_of BTO:0001188 ! root
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-14T12:46:00Z
 
 [Term]
 id: BTO:0005700
 name: culture condition:6-deoxy-6-sulfoglucose-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-14T12:51:10Z
 
 [Term]
 id: BTO:0005701
 name: culture condition:carbon disulfide-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-14T12:52:18Z
 
 [Term]
 id: BTO:0005702
 name: culture condition:ferulate-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-14T12:52:55Z
 
 [Term]
 id: BTO:0005703
 name: culture condition:vanillate-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-14T12:58:07Z
 
 [Term]
@@ -42547,7 +42564,7 @@ name: milk gland
 def: "Larval nutrition is provided via a modified accessory gland, a milk gland, that empties into the uterus. The milk gland is connected to the dorsal side of the uterus and expands throughout the abdominal cavity of the fly as bifurcating tubules intertwining with fat body tissue. The lumen of the milk gland is surrounded by secretory and epithelial cells." [PMID:18647605]
 synonym: "insect milk gland" RELATED []
 is_a: BTO:0000522 ! gland
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-16T16:38:45Z
 
 [Term]
@@ -42556,7 +42573,7 @@ name: headfoot muscle
 def: "The head-foot is the part you see most easily in slugs and snails. It is mostly a muscular organ covered in cilia and rich in mucous cells, which the mollusc uses to move around, it normally tapers to a tail at one end and has a head incorporated in the front. The head includes a mouth, eyes and tentacles, the last two may be much reduced or even absent. In those species with shells the head-foot can be drawn into the shell." [Molluscs_General_Anatomy:http\://www.earthlife.net/inverts/mollusca.html]
 synonym: "head-foot muscle" RELATED []
 relationship: part_of BTO:0003509 ! headfoot
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-15T16:36:07Z
 
 [Term]
@@ -42565,7 +42582,7 @@ name: HEY-1B cell
 def: "Human highly-invasive ovarian cancer cell line." [PMID:23376478]
 synonym: "Hey1b cell" RELATED []
 relationship: develops_from BTO:0002590 ! HEY cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-15T16:40:43Z
 
 [Term]
@@ -42573,14 +42590,14 @@ id: BTO:0005707
 name: HMEEC cell
 def: "Human middle ear epithelial cell line." [PMID:24012219]
 is_a: BTO:0005708 ! middle ear cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-15T16:45:33Z
 
 [Term]
 id: BTO:0005708
 name: middle ear cell line
 relationship: develops_from BTO:0002099 ! middle ear
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-15T16:46:46Z
 
 [Term]
@@ -42590,7 +42607,7 @@ def: "Human melanoma cell line." [PMID:23087082]
 synonym: "IGR3 cell" RELATED []
 synonym: "IgR3 cell" RELATED []
 is_a: BTO:0000849 ! melanoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-15T16:51:15Z
 
 [Term]
@@ -42599,7 +42616,7 @@ name: M5 melanoma cell
 def: "Human melanoma cell line." [PMID:2415245]
 synonym: "M5 cell" RELATED []
 is_a: BTO:0000849 ! melanoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-15T16:52:31Z
 
 [Term]
@@ -42607,7 +42624,7 @@ id: BTO:0005711
 name: Mel007 cell
 def: "Human melanoma cell line." [PMID:18245485]
 is_a: BTO:0000849 ! melanoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-15T17:11:41Z
 
 [Term]
@@ -42615,7 +42632,7 @@ id: BTO:0005712
 name: Mel-AT cell
 def: "Human melanoma cell line." [PMID:15827341]
 is_a: BTO:0000849 ! melanoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-15T17:17:01Z
 
 [Term]
@@ -42623,7 +42640,7 @@ id: BTO:0005713
 name: Mel-CV cell
 def: "Human melanoma cell line." [PMID:15827341]
 is_a: BTO:0000849 ! melanoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-15T17:18:04Z
 
 [Term]
@@ -42631,7 +42648,7 @@ id: BTO:0005714
 name: Mel-FH cell
 def: "Human melanoma cell line." [PMID:15827341]
 is_a: BTO:0000849 ! melanoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-15T17:18:37Z
 
 [Term]
@@ -42639,7 +42656,7 @@ id: BTO:0005715
 name: Mel-RM cell
 def: "Human melanoma cell line." [PMID:15827341]
 is_a: BTO:0000849 ! melanoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-15T17:19:43Z
 
 [Term]
@@ -42647,7 +42664,7 @@ id: BTO:0005716
 name: Me4405 cell
 def: "Human melanoma cell line." [PMID:15827341]
 is_a: BTO:0000849 ! melanoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-15T17:20:39Z
 
 [Term]
@@ -42657,7 +42674,7 @@ def: "Human melanoma cell line." [PMID:15827341]
 synonym: "MM 200 cell" RELATED []
 synonym: "MM-200 cell" RELATED []
 is_a: BTO:0000849 ! melanoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-15T17:21:14Z
 
 [Term]
@@ -42665,7 +42682,7 @@ id: BTO:0005718
 name: Mel-JD cell
 def: "Human melanoma cell line." [PMID:24574456]
 is_a: BTO:0000849 ! melanoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-15T17:23:49Z
 
 [Term]
@@ -42673,7 +42690,7 @@ id: BTO:0005719
 name: Mel-RMU cell
 def: "Human malignant melanoma cell line." [PMID:18949058]
 is_a: BTO:0000849 ! melanoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-15T17:27:34Z
 
 [Term]
@@ -42682,7 +42699,7 @@ name: MOLM-14 cell
 def: "Human acute myeloid leukemia cell line. Sister cell line of MOLM-13 cell." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 synonym: "MOLM14 cell" RELATED []
 is_a: BTO:0001883 ! acute myeloid leukemia cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-16T16:44:42Z
 
 [Term]
@@ -42693,7 +42710,7 @@ comment: Contaminated. Shown to be a HeLa derivative.
 synonym: "QGY cell" RELATED []
 synonym: "QGY7703 cell" RELATED []
 relationship: develops_from BTO:0000567 ! HeLa cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-16T17:16:38Z
 
 [Term]
@@ -42701,7 +42718,7 @@ id: BTO:0005722
 name: retrocerebral organ
 def: "A small glandular organ, attached to the epidermis above and behind the brain, comprised of the retrocerebral sac and the subcerebral glands." [Dictionary_of_Invertebrate_Zoology:http\://species-id.net/zooterms/]
 is_a: BTO:0001488 ! endocrine gland
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-20T09:05:04Z
 
 [Term]
@@ -42709,7 +42726,7 @@ id: BTO:0005723
 name: cerebral organ
 def: "In Nemertina one of paired ciliated tubes associated with the dorsal ganglion and opening to the exterior, that function as chemical sense organs. In Sipuncula the anterior margin of the cerebral ganglion made up of high columnar epithelium, probably not sensory in function." [Dictionary_of_Invertebrate_Zoology:http\://species-id.net/zooterms/]
 is_a: BTO:0000202 ! sense organ
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-20T09:08:25Z
 
 [Term]
@@ -42717,7 +42734,7 @@ id: BTO:0005724
 name: CG-4 cell
 def: "A permanent cell line of rat central nervous system glial precursors from primary cultures of bipotential oligodendrocyte-type 2-astrocyte (O-2A) progenitor cells. The CG-4 cells have a normal karyotype and display the properties of normal O-2A cells." [PMID:1613821]
 is_a: BTO:0000872 ! oligodendrocytic cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-20T09:21:28Z
 
 [Term]
@@ -42726,7 +42743,7 @@ name: HuH-7-Lunet cell
 synonym: "Huh7-Lunet cell" RELATED []
 synonym: "Lunet cell" RELATED []
 relationship: develops_from BTO:0001950 ! HuH-7 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-20T09:57:36Z
 
 [Term]
@@ -42734,7 +42751,7 @@ id: BTO:0005726
 name: Lunet-Con1 cell
 def: "Lunet-Con1 cell line was derived from Lunet cell line." [PMID:17552027]
 relationship: develops_from BTO:0005725 ! HuH-7-Lunet cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-20T09:57:55Z
 
 [Term]
@@ -42744,7 +42761,7 @@ def: "Fumarate hydratase deficient hereditary leiomyomatosis renal cell carcinom
 synonym: "UOK 262 cell" RELATED []
 synonym: "UOK262 cell" RELATED []
 is_a: BTO:0000383 ! renal cell carcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-20T11:16:58Z
 
 [Term]
@@ -42752,7 +42769,7 @@ id: BTO:0005728
 name: gynophore
 def: "A gynophore is the stalk of certain flowers which supports the gynoecium elevating it above the branching points of other floral parts." [Wikipedia:The_Free_Encyclopedia]
 relationship: part_of BTO:0000469 ! flower
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-24T16:18:22Z
 
 [Term]
@@ -42760,49 +42777,49 @@ id: BTO:0005729
 name: chemoreceptor cell
 def: "A sensory nerve cell or sense organ, as of smell or taste, that responds to chemical stimuli." [The_American_Heritage_Medical_Dictionary:Copyright_2007]
 is_a: BTO:0001037 ! sensory cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-27T09:44:25Z
 
 [Term]
 id: BTO:0005730
 name: culture condition:chitin-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-27T09:54:12Z
 
 [Term]
 id: BTO:0005731
 name: culture condition:dichloromethane-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-27T09:55:29Z
 
 [Term]
 id: BTO:0005732
 name: culture condition:gentisate-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-27T09:56:40Z
 
 [Term]
 id: BTO:0005733
 name: culture condition:methyl ferulate-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-27T09:57:13Z
 
 [Term]
 id: BTO:0005734
 name: culture condition:methyl vanillate-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-27T09:57:22Z
 
 [Term]
 id: BTO:0005735
 name: culture condition:rye flour-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-27T09:58:07Z
 
 [Term]
@@ -42811,7 +42828,7 @@ name: Hepa-RG cell
 def: "Terminally differentiated hepatic cells derived from a human hepatic progenitor cell line that retains many characteristics of primary human hepatocytes." [LifeTechnologies:http\://www.lifetechnologies.com/]
 synonym: "HepaRG cell" RELATED []
 is_a: BTO:0000224 ! liver cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-27T10:07:58Z
 
 [Term]
@@ -42819,14 +42836,14 @@ id: BTO:0005737
 name: HMVEC cell
 def: "Human microvascular endothelial cell line." [PMID:15358096]
 is_a: BTO:0003124 ! microvascular endothelial cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-27T10:12:53Z
 
 [Term]
 id: BTO:0005738
 name: lung microvascular endothelial cell
 is_a: BTO:0003124 ! microvascular endothelial cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-27T10:16:28Z
 
 [Term]
@@ -42835,7 +42852,7 @@ name: transfer cell
 def: "A type of plant cell specialized for the short-distance high-volume transport of materials. Transfer cells have numerous knobs and ridges on the inner surface of the primary cell wall. These greatly increase the surface area of the plasma membrane, which follows the contours of the protuberances. The expanded plasma membrane can accommodate a large number of transport proteins, which are responsible for transporting materials in or out of the cell. Transfer cells are found mainly in salt-secreting glands and in regions where photosynthate (sugar) is loaded or unloaded into sieve elements of phloem." [Encyclopedia.com:http\://www.encyclopedia.com]
 relationship: develops_from BTO:0005742 ! transfer cell precursor
 relationship: part_of BTO:0001461 ! whole plant
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-27T11:26:58Z
 
 [Term]
@@ -42846,7 +42863,7 @@ synonym: "plant precursor cell" RELATED []
 relationship: part_of BTO:0000034 ! apical meristem
 relationship: part_of BTO:0001461 ! whole plant
 relationship: part_of BTO:0005741 ! lateral meristem
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-27T11:37:50Z
 
 [Term]
@@ -42854,14 +42871,14 @@ id: BTO:0005741
 name: lateral meristem
 def: "A meristem in vascular plants, such as the cambium, in which secondary growth occurs." [Dictionary:http\://www.thefreedictionary.com/]
 is_a: BTO:0000852 ! meristem
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-27T11:42:21Z
 
 [Term]
 id: BTO:0005742
 name: transfer cell precursor
 is_a: BTO:0005740 ! plant stem cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-27T11:43:34Z
 
 [Term]
@@ -42871,7 +42888,7 @@ def: "The post-flowering stage of a plant." [PMID:22558253]
 synonym: "mature plant" RELATED []
 synonym: "post-flowering stage" RELATED []
 is_a: BTO:0000720 ! plant form
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-27T11:55:16Z
 
 [Term]
@@ -42880,7 +42897,7 @@ name: vegetative stage
 def: "The pre-flowering stage of a plant." [PMID:22558253]
 synonym: "pre-flowering stage" RELATED []
 is_a: BTO:0000720 ! plant form
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-04-27T11:57:29Z
 
 [Term]
@@ -42888,7 +42905,7 @@ id: BTO:0005745
 name: SHI-1 cell
 def: "Human acute myelocytic leukemia cell line, established in 2002 from the bone marrow of a 37-year-old male with relapsed acute monocytic leukemia (AML-M5b)." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 is_a: BTO:0001883 ! acute myeloid leukemia cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-06-09T13:02:01Z
 
 [Term]
@@ -42897,7 +42914,7 @@ name: gynostemium
 def: "The column formed by the union of androecium and gynoecium, as in an orchid." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/gynostemium]
 synonym: "column" RELATED []
 relationship: part_of BTO:0000469 ! flower
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-06-12T10:14:02Z
 
 [Term]
@@ -42906,7 +42923,7 @@ name: IGR-37 cell
 def: "Human melanoma cell line, established from the lymph node metastasis (groin) of a 26-year-old man with malignant melanoma." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 synonym: "IGR37 cell" RELATED []
 is_a: BTO:0000849 ! melanoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-13T12:16:53Z
 
 [Term]
@@ -42914,7 +42931,7 @@ id: BTO:0005748
 name: AC2M2 cell
 def: "Highly metastatic murine mammary carcinoma cell line." [PMID:15987432]
 is_a: BTO:0000356 ! breast cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-13T12:48:38Z
 
 [Term]
@@ -42924,7 +42941,7 @@ def: "An immortalized but nontransformed cell line, derived from ciliated human 
 comment: Added as synonym to BTO:0002734: 16-HBEo cell.
 synonym: "16HBE cell" RELATED []
 is_obsolete: true
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-13T12:53:26Z
 
 [Term]
@@ -42932,7 +42949,7 @@ id: BTO:0005750
 name: dentate granule cell
 def: "The principal cell type of the dentate gyrus is the dentate granule cell. The granule cells are tightly packed in the granular cell layer of the dentate gyrus." [Wikipedia:The_Free_Encyclopedia]
 relationship: part_of BTO:0002496 ! dentate gyrus
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-13T13:19:58Z
 
 [Term]
@@ -42943,7 +42960,7 @@ synonym: "C8161 cl.9 cell" RELATED []
 synonym: "C8161 subclone 9cell" RELATED []
 synonym: "C8161cl.9 cell" RELATED []
 relationship: develops_from BTO:0002016 ! C-8161 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-13T13:40:07Z
 
 [Term]
@@ -42951,7 +42968,7 @@ id: BTO:0005752
 name: CHO-13-5-1 cell
 def: "LDL receptor-related protein 1-deficient mutant CHO cell line." [PMID:20919742]
 relationship: develops_from BTO:0000246 ! CHO cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-13T13:54:52Z
 
 [Term]
@@ -42959,14 +42976,14 @@ id: BTO:0005753
 name: CHO-A7 cell
 def: "Arginase-deficient CHO cell variant." [PMID:6727873]
 relationship: develops_from BTO:0000246 ! CHO cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-13T13:58:09Z
 
 [Term]
 id: BTO:0005754
 name: choroid plexus cancer cell
 relationship: develops_from BTO:0000258 ! choroid plexus
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-13T14:00:56Z
 
 [Term]
@@ -42975,7 +42992,7 @@ name: choroid plexus papilloma cell
 def: "Choroid plexus papillomas are an uncommon, benign neuroepithelial intraventricular tumour which can occur in both the paediatric and adult population." [Radiopaedia.org:http\://radiopaedia.org/articles/choroid-plexus-papilloma-1]
 synonym: "CPP cell" RELATED []
 is_a: BTO:0005754 ! choroid plexus cancer cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-13T14:01:16Z
 
 [Term]
@@ -42984,7 +43001,7 @@ name: decidual stromal cell
 def: "Decidual stromal cells are the main cellular component of the human decidua." [PMID:11719592]
 synonym: "DSC cell" RELATED []
 is_a: BTO:0002770 ! decidual cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-13T14:07:05Z
 
 [Term]
@@ -42993,7 +43010,7 @@ name: EC-9706 cell
 def: "Human esophageal carcinoma cell line." [PMID:21223795]
 synonym: "EC9706 cell" RELATED []
 is_a: BTO:0002817 ! esophageal cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-13T14:12:41Z
 
 [Term]
@@ -43005,7 +43022,7 @@ synonym: "EC109 cell" RELATED []
 synonym: "Eca 109 cell" RELATED []
 synonym: "Eca109 cell" RELATED []
 is_a: BTO:0002428 ! esophageal squamous cell carcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-13T14:14:44Z
 
 [Term]
@@ -43013,42 +43030,42 @@ id: BTO:0005759
 name: epitheliocyte
 def: "An in vitro tissue culture epithelial cell." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 is_a: BTO:0001120 ! epithelial cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-13T14:19:51Z
 
 [Term]
 id: BTO:0005760
 name: alveolar epithelial cell
 relationship: part_of BTO:0003511 ! alveolar epithelium
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-27T17:01:09Z
 
 [Term]
 id: BTO:0005761
 name: adrenal glomerulosa cell
 relationship: part_of BTO:0000048 ! zona glomerulosa
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-27T17:02:13Z
 
 [Term]
 id: BTO:0005762
 name: colonic mucosa cell
 relationship: part_of BTO:0000271 ! colonic mucosa
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-27T17:05:05Z
 
 [Term]
 id: BTO:0005763
 name: culture condition:2,4-dinitroanisole-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-27T17:07:05Z
 
 [Term]
 id: BTO:0005764
 name: culture condition:chitosan-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-27T17:10:18Z
 
 [Term]
@@ -43057,7 +43074,7 @@ name: 2fTGH cell
 def: "The human sarcoma cell line HT 1080 was transfected with a vector encoding the selectable marker guanine phosphoribosyltransferase regulated by alpha interferon to create the 2fTGH cell line, enabling the selection of mutations in genes encoding components of the interferon signalling pathway." [Public_Health_England:http\://www.phe-culturecollections.org.uk/products/celllines/]
 synonym: "2-fTGH cell" RELATED []
 relationship: develops_from BTO:0001282 ! HT-1080 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-28T08:33:02Z
 
 [Term]
@@ -43066,7 +43083,7 @@ name: A2780/CP cell
 def: "Cisplatin-resistant variant of the human ovarian carcinoma cell line A2780." [PMID:20568902]
 comment: Seems to be a synonym of A2780/CP70 cell.
 is_obsolete: true
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-28T08:41:22Z
 
 [Term]
@@ -43074,7 +43091,7 @@ id: BTO:0005767
 name: buccal gland
 def: "Any of the small racemose mucous glands in the mucous membrane lining the cheeks." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/buccal_gland]
 relationship: part_of BTO:0001754 ! cheek
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-28T08:52:33Z
 
 [Term]
@@ -43082,21 +43099,21 @@ id: BTO:0005768
 name: epididymal epithelium
 def: "In the epididymal epithelium, the tall columnar cells and shorter basal cells give the appearance of two rows of nuclei. However, both types of cells together really form a single layer with every cell sitting on the basement membrane. Hence this epithelium is pseudostratified. The epididymal epithelium is supported by loose connective tissue." [SIUC_School_of_Medicine_Anatomy:http\://www.siumed.edu/~dking2/intro/RE034c.htm]
 relationship: part_of BTO:0000408 ! epididymis
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-28T09:02:57Z
 
 [Term]
 id: BTO:0005769
 name: buccal mucosa cancer cell
 relationship: develops_from BTO:0003833 ! buccal mucosa
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-28T09:24:45Z
 
 [Term]
 id: BTO:0005770
 name: buccal mucosa cancer cell line
 relationship: develops_from BTO:0005769 ! buccal mucosa cancer cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-28T09:26:09Z
 
 [Term]
@@ -43104,7 +43121,7 @@ id: BTO:0005771
 name: HO-1-N-1 cell
 def: "Human squamous carcinoma cell line of the buccal mucosa." [Cellbank:http\://cellbank.nibiohn.go.jp//legacy/celldata/]
 is_a: BTO:0005770 ! buccal mucosa cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-28T09:26:28Z
 
 [Term]
@@ -43119,7 +43136,7 @@ synonym: "HO8910/PM cell" RELATED []
 synonym: "HO8910PM cell" RELATED []
 synonym: "HO8910pm cell" RELATED []
 relationship: develops_from BTO:0005438 ! HO-8910 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-28T09:29:59Z
 
 [Term]
@@ -43128,7 +43145,7 @@ name: HuH-1 cell
 def: "Human hepatoma cell line, established from a liver tumor of a 53-year-old japanese male." [Cellbank:http\://cellbank.nibiohn.go.jp//legacy/celldata/]
 synonym: "huH-1 cell" RELATED []
 is_a: BTO:0000578 ! hepatoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-28T10:03:27Z
 
 [Term]
@@ -43137,7 +43154,7 @@ name: IPC-298 cell
 def: "Human melanoma cell line, established from the primary tumor (right cervical) of a 64-year-old woman with cutaneous melanoma." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 synonym: "IPC298 cell" RELATED []
 is_a: BTO:0000849 ! melanoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-28T10:09:39Z
 
 [Term]
@@ -43146,7 +43163,7 @@ name: KBM-7 cell
 def: "Human chronic myeloid leukemia cell line." [PMID:24928376]
 synonym: "KBM7 cell" RELATED []
 is_a: BTO:0002580 ! chronic myeloid leukemia cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-28T10:15:52Z
 
 [Term]
@@ -43155,7 +43172,7 @@ name: LN-71 cell
 def: "Human central nervous system glioma cell line." [PMID:19845488]
 synonym: "LN71 cell" RELATED []
 is_a: BTO:0000711 ! glioma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-29T10:47:34Z
 
 [Term]
@@ -43163,7 +43180,7 @@ id: BTO:0005777
 name: midgut diverticulum
 def: "The midgut of arachnids and crustaceans is a simple, often relatively short tube, bit it gives rise to large tubular or branched midgut diverticula." [Concise_Encyclopedia_Biology:https\://books.google.de/]
 relationship: part_of BTO:0000863 ! midgut
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-29T11:11:37Z
 
 [Term]
@@ -43171,7 +43188,7 @@ id: BTO:0005778
 name: myeloblastoma cell
 def: "A focal malignant tumor composed of myeloblasts or early myeloid precursors occurring outside the bone marrow." [Dorlands_Medical_Dictionary:MerckMedicus]
 relationship: develops_from BTO:0000187 ! myeloblast
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-29T11:22:44Z
 
 [Term]
@@ -43181,7 +43198,7 @@ def: "Human adenocarcinoma non-small cell lung cancer cell line." [ATCC_American
 synonym: "H-1838 cell" RELATED []
 synonym: "H1838 cell" RELATED []
 is_a: BTO:0002553 ! non-small cell lung cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-29T11:30:03Z
 
 [Term]
@@ -43190,7 +43207,7 @@ name: WM-902B cell
 def: "Human melanoma cell line." [PMID:18790768]
 synonym: "WM902b cell" RELATED []
 is_a: BTO:0000849 ! melanoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-30T16:34:33Z
 
 [Term]
@@ -43198,7 +43215,7 @@ id: BTO:0005781
 name: uroepithelial cell
 synonym: "urothelial cell" RELATED []
 relationship: part_of BTO:0003906 ! uroepithelium
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-30T16:38:03Z
 
 [Term]
@@ -43206,7 +43223,7 @@ id: BTO:0005782
 name: THLE-5b cell
 def: "Nonmalignant human hepatocyte cell line." [PMID:17950097]
 is_a: BTO:0002931 ! liver epithelial cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-30T16:41:19Z
 
 [Term]
@@ -43217,7 +43234,7 @@ synonym: "tendon cell" RELATED []
 synonym: "tendon fibroblast" RELATED []
 is_a: BTO:0000452 ! fibroblast
 relationship: part_of BTO:0001356 ! tendon
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-30T16:46:52Z
 
 [Term]
@@ -43226,7 +43243,7 @@ name: syncytium
 def: "A multinucleate mass of protoplasm produced by the merging of cells." [Dorlands_Medical_Dictionary:MerckMedicus]
 synonym: "symplasm" RELATED []
 is_a: BTO:0002322 ! cell property
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-30T16:54:44Z
 
 [Term]
@@ -43235,7 +43252,7 @@ name: embryonic syncytium
 def: "Another correct and well-established use of the word syncytium is found in animal embryology to refer to the coenocytic blastoderm embryos of invertebrates, such as Drosophila melanogaster." [Wikipedia:The_Free_Encyclopedia]
 synonym: "syncytium" RELATED []
 is_a: BTO:0000174 ! embryonic structure
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-30T17:01:15Z
 
 [Term]
@@ -43244,7 +43261,7 @@ name: SNU-1 cell
 def: "Human gastric carcinoma cell line, established from a 44 years old asian male." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 synonym: "SNU1 cell" RELATED []
 is_a: BTO:0000787 ! gastric cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-09-30T17:08:14Z
 
 [Term]
@@ -43254,7 +43271,7 @@ def: "An elongated, spindle-shaped, cell that is located between the basal lamin
 synonym: "skeletal muscle satellite stem cell" RELATED []
 is_a: BTO:0005300 ! muscle stem cell
 relationship: part_of BTO:0001103 ! skeletal muscle
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-10-01T09:09:21Z
 
 [Term]
@@ -43263,7 +43280,7 @@ name: SH-EP1 cell
 def: "Human neuroblastoma cell line, established from brain bone marrow tissue from a 4 years old caucasian white with neuroblastoma." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 synonym: "SH-EPi cell" RELATED []
 relationship: develops_from BTO:0005397 ! SH-EP cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-10-01T09:14:25Z
 
 [Term]
@@ -43271,7 +43288,7 @@ id: BTO:0005789
 name: root band
 def: "The node consists of a growth ring or intercalary meristem, the root band (containing root primordia) and a bud above the leaf scar where the leaf sheath attaches, which delimits the node from the internode below." [Australian_Government:The_Biology_and_Ecology_of_Sugarcane_in_Australia]
 is_a: BTO:0001156 ! node
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-10-01T10:05:17Z
 
 [Term]
@@ -43281,7 +43298,7 @@ def: "Granulocyte precursor, developing from the myeloblast and developing into 
 synonym: "progranulocyte" RELATED []
 is_a: BTO:0000725 ! hematopoietic stem cell
 relationship: develops_from BTO:0000187 ! myeloblast
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-10-01T10:18:20Z
 
 [Term]
@@ -43289,7 +43306,7 @@ id: BTO:0005791
 name: enamel knot
 def: "In tooth development, the enamel knot is a localization of cells on an enamel organ that appear thickened in the center of the inner enamel epithelium." [Wikipedia:The_Free_Encyclopedia]
 relationship: part_of BTO:0001722 ! enamel organ
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-10-01T10:24:31Z
 
 [Term]
@@ -43297,7 +43314,7 @@ id: BTO:0005792
 name: primary enamel knot
 def: "The primary enamel knot forms at the tip of the bud during the cap stage of tooth development. This primary enamel knot is removed by apoptosis." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0005791 ! enamel knot
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-10-01T10:24:40Z
 
 [Term]
@@ -43305,14 +43322,14 @@ id: BTO:0005793
 name: secondary enamel knot
 def: "The primary enamel knot forms at the tip of the bud during the cap stage of tooth development. This primary enamel knot is removed by apoptosis. Later, secondary enamel knots appear that regulate the formation of the future cusps of the teeth." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0005791 ! enamel knot
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-10-01T10:25:22Z
 
 [Term]
 id: BTO:0005794
 name: ophthalmic lavage fluid
 relationship: realized_in BTO:0000439 ! eye
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-10-16T13:30:45Z
 
 [Term]
@@ -43320,7 +43337,7 @@ id: BTO:0005795
 name: osteoma cell
 def: "A benign tumor composed of bony tissue, often developing on the skull." [The_American_Heritage_Medical_Dictionary:Copyright_2007]
 is_a: BTO:0000372 ! bone cancer cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-10-16T13:37:37Z
 
 [Term]
@@ -43329,7 +43346,7 @@ name: PEO-1 cell
 def: "Human ovarian adenocarcinoma cell line." [PMID:3167863]
 synonym: "PEO1 cell" RELATED []
 is_a: BTO:0001882 ! ovary adenocarcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-10-16T13:40:22Z
 
 [Term]
@@ -43338,7 +43355,7 @@ name: PEO-4 cell
 def: "Human ovarian adenocarcinoma cell line." [PMID:3167863]
 synonym: "PEO4 cell" RELATED []
 is_a: BTO:0001882 ! ovary adenocarcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-10-16T13:41:49Z
 
 [Term]
@@ -43347,7 +43364,7 @@ name: PEO-6 cell
 def: "Human ovarian adenocarcinoma cell line." [PMID:3167863]
 synonym: "PEO6 cell" RELATED []
 is_a: BTO:0001882 ! ovary adenocarcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-10-16T13:42:43Z
 
 [Term]
@@ -43360,7 +43377,7 @@ synonym: "corticotrop adenoma cell" RELATED []
 synonym: "corticotropinoma cell" RELATED []
 is_a: BTO:0001076 ! pituitary gland tumor cell
 relationship: develops_from BTO:0002509 ! corticotropic cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-10-16T13:51:44Z
 
 [Term]
@@ -43369,7 +43386,7 @@ name: Neu-7 cell
 def: "Murine astrocyte cell line." [PMID:22505518]
 synonym: "Neu7 cell" RELATED []
 is_a: BTO:0002600 ! astrocyte cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-10-16T16:49:51Z
 
 [Term]
@@ -43377,7 +43394,7 @@ id: BTO:0005801
 name: K-562/CP cell
 def: "Cisplatin resistant subline of K-562 leukemia cell line." [PMID:25356864]
 relationship: develops_from BTO:0000664 ! K-562 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-10-16T17:17:18Z
 
 [Term]
@@ -43387,7 +43404,7 @@ def: "The dentate gyrus HICAP cells (Hilar Commissural-Associational pathway rel
 synonym: "hilar cell" RELATED []
 synonym: "hilar neuron" RELATED []
 relationship: part_of BTO:0002496 ! dentate gyrus
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-10-16T17:30:00Z
 
 [Term]
@@ -43395,7 +43412,7 @@ id: BTO:0005803
 name: dentate gyrus HIPP cell
 def: "The dentate gyrus HIPP cell (Hilar Perforant Path-associated cell) is an interneuron in the hippocampal formation. It is a long-spined multipolar cell that is conspicuous of distribution of copious, long and often branched spines over its cell body and dendrites. The axonal plexus can extend as much as 3.5mm along the septotemporal axis of the dentate gyrus. Since inhibitory interneurons typically have aspiny dendrites and relatively local axonal plexuses, this long spined multipolar/HIPP cell is a very atypical interneuron." [Neurolex.org:http\://neurolex.org/wiki/Category\:Hippocampal_neuron]
 relationship: part_of BTO:0002496 ! dentate gyrus
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-10-16T17:32:38Z
 
 [Term]
@@ -43404,7 +43421,7 @@ name: dentate gyrus IS-I cell
 def: "The interneuron-specific subpopulation of interneurons have axons that preferentially innervate other interneurons. The dentate gyrus IS-I class interneurons are visualized by immunostaining for Calretinin (CR)and establish multiple symmetrical synapses on the dendrites and somata of other CR-positive IS-I cells, Calbindin (CB) containing interneurons, and VIP-positive basket cells, but they do not innervate PV-containing interneurons. The dendrites of dentate gyrus IS I neurons appear in all layers of dentate gyrus and more characteristic feature of these dendrites is that they form long dendrodendritic junctions with each other." [Neurolex.org:http\://neurolex.org/wiki/Category\:Hippocampal_neuron]
 synonym: "dentate gyrus interneuron-specific cell" RELATED []
 relationship: part_of BTO:0002496 ! dentate gyrus
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-10-16T17:33:40Z
 
 [Term]
@@ -43413,7 +43430,7 @@ name: dentate gyrus IS-II cell
 def: "The Interneuron-Specific subpopulation of interneurons have axons that preferentially innervate other interneurons. The dentate gyrus IS-II class interneurons are visualized by immunostaining for Vasoactive Intestinal Polypeptide (VIP). The dendrites of dentate gyrus IS-II cells are present in all layers of dentate gyrus." [Neurolex.org:http\://neurolex.org/wiki/Category\:Hippocampal_neuron]
 synonym: "dentate gyrus interneuron-specific II cell" RELATED []
 relationship: part_of BTO:0002496 ! dentate gyrus
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-10-16T17:36:09Z
 
 [Term]
@@ -43421,7 +43438,7 @@ id: BTO:0005806
 name: flexor tendon
 def: "The flexor tendons are strong smooth cords that connect the muscles of the forearm to the bones in the fingers and thumb. There are two to each finger and one for the thumb." [BSSH_The_British_Society_for_Surgery_of_the_Hand:http\://www.bssh.ac.uk/patients/commonhandconditions/flexortendoninjury]
 is_a: BTO:0001356 ! tendon
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-10-20T15:10:05Z
 
 [Term]
@@ -43429,7 +43446,7 @@ id: BTO:0005807
 name: GI-LA-N cell
 def: "Human neuroblastoma cell line; established from the metastases of a lymph node biopsy of a stage III neuroblastoma after 7 months of chemotherapy." [PMID:3422578]
 is_a: BTO:0000932 ! neuroblastoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-10-20T15:35:01Z
 
 [Term]
@@ -43437,7 +43454,7 @@ id: BTO:0005808
 name: GI-ME-N cell
 def: "Human neuroblastoma cell line; established from the metastases of a bone marrow specimen of a stage IV neuroblastoma after 6 months of chemotherapy." [PMID:3422578]
 is_a: BTO:0000932 ! neuroblastoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-10-20T15:37:19Z
 
 [Term]
@@ -43445,7 +43462,7 @@ id: BTO:0005809
 name: HMVEC-dLy cell
 def: "Normal human dermal lymphatic microvascular endothelial cell line." [PMID:24631293]
 is_a: BTO:0005737 ! HMVEC cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-10-20T15:53:39Z
 
 [Term]
@@ -43453,7 +43470,7 @@ id: BTO:0005810
 name: immune system
 def: "The bodily system that protects the body from foreign substances, cells, and tissues by producing the immune response and that includes especially the thymus, spleen, lymph nodes, special deposits of lymphoid tissue (as in the gastrointestinal tract and bone marrow), macrophages, lymphocytes including the B cells and T cells, and antibodies." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/imune_system]
 relationship: part_of BTO:0001489 ! whole body
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-10-20T16:30:07Z
 
 [Term]
@@ -43463,7 +43480,7 @@ def: "A leaf near the apex of a stem that is still rolled into a cylinder." [Pla
 synonym: "leaf roll" RELATED []
 synonym: "leaf roll tissue" RELATED []
 is_a: BTO:0000713 ! leaf
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2015-10-24T14:37:18Z
 
 [Term]
@@ -43471,14 +43488,14 @@ id: BTO:0005812
 name: lung endothelial cell
 is_a: BTO:0001176 ! endothelial cell
 relationship: part_of BTO:0004128 ! lung endothelium
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-12T15:04:02Z
 
 [Term]
 id: BTO:0005813
 name: pancreatic islet cell
 relationship: part_of BTO:0000991 ! pancreatic islet
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-12T15:23:55Z
 
 [Term]
@@ -43493,7 +43510,7 @@ synonym: "Bel-7404 cell" RELATED []
 synonym: "BEL7404 cell" RELATED []
 synonym: "Bel7404 cell" RELATED []
 relationship: develops_from BTO:0000567 ! HeLa cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-14T08:57:29Z
 
 [Term]
@@ -43502,7 +43519,7 @@ name: A-375.S2 cell
 def: "Skin malignant melanoma cell line. This line was cloned by limiting dilution from the A375 melanoma cell line." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 synonym: "A375.S2 cell" RELATED []
 relationship: develops_from BTO:0002806 ! A-375 cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-14T09:04:08Z
 
 [Term]
@@ -43510,7 +43527,7 @@ id: BTO:0005816
 name: A549-CR cell
 def: "A549-CR cell line, was established by repeated subculturing of A549 cells with increasing Cisplatin." [PMID:26692948]
 relationship: develops_from BTO:0000018 ! A-549 cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-14T09:19:16Z
 
 [Term]
@@ -43519,7 +43536,7 @@ name: adrenocortical cell
 def: "Cell, pertaining to or arising from the cortex of the adrenal gland." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 synonym: "corticoadrenal cell" RELATED []
 relationship: part_of BTO:0000045 ! adrenal cortex
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-14T09:28:52Z
 
 [Term]
@@ -43528,7 +43545,7 @@ name: BIN-67 cell
 def: "Small cell ovarian carcinoma of the hypercalcemic type, SCCOHT cell line." [PMID:23433318]
 synonym: "BIN67 cell" RELATED []
 is_a: BTO:0000811 ! ovary cancer cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-14T10:02:27Z
 
 [Term]
@@ -43536,7 +43553,7 @@ id: BTO:0005819
 name: histaminergic neuron
 def: "Histaminergic neurons in mammalian brain are located exclusively in the tuberomamillary nucleus of the posterior hypothalamus and send their axons all over the central nervous system; The cell body of C2 is an identified histaminergic neuron in the cerebral ganglion of Aplysia." [PMID:18626069, PMID:6179570]
 is_a: BTO:0000938 ! neuron
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-14T10:13:59Z
 
 [Term]
@@ -43546,7 +43563,7 @@ def: "Mouse brain neuronal cell line; established from cultures of a tumor that 
 is_a: BTO:0000690 ! brain cancer cell line
 is_a: BTO:0000947 ! neuronal cell line
 is_a: BTO:0003694 ! CNS cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-15T08:40:12Z
 
 [Term]
@@ -43556,7 +43573,7 @@ def: "Mouse lung carcinoma cell line; established from mouse strain C57BL/lcrf .
 synonym: "CMT 167 cell" RELATED []
 synonym: "CMT167 cell" RELATED []
 is_a: BTO:0000762 ! lung cancer cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-15T09:32:57Z
 
 [Term]
@@ -43568,7 +43585,7 @@ synonym: "auditory hair cell" RELATED []
 synonym: "Cell of Corti" RELATED []
 synonym: "Corti cell" RELATED []
 relationship: part_of BTO:0001691 ! spiral organ
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-15T09:52:44Z
 
 [Term]
@@ -43576,7 +43593,7 @@ id: BTO:0005823
 name: hair-cell stereocilium
 def: "In the inner ear, stereocilia are the mechanosensing organelles of hair cells, which respond to fluid motion in numerous types of animals for various functions, including hearing and balance. They are about 10 to 50 micrometers in length and share some similar features of microvilli. Stereocilia exist in the auditory and vestibular systems." [Wikipedia:The_Free_Encyclopedia]
 relationship: part_of BTO:0004744 ! hair cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-15T09:54:25Z
 
 [Term]
@@ -43584,7 +43601,7 @@ id: BTO:0005824
 name: vestibular hair cell
 def: "Vestibular hair cells are in the sensory epithelium of the maculae and cristae of the membranous labyrinth of the internal ear." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 relationship: part_of BTO:0005581 ! vestibular sensory epithelium
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-15T10:04:32Z
 
 [Term]
@@ -43593,7 +43610,7 @@ name: ctenidium
 def: "1: The gill of a mollusk consisting typically of a respiratory structure that resembles a comb or feather, has a main stem with lateral lamellae, and is developed from the inner side of the mantle. 2:A structure consisting of a row of spines resembling the teeth of a comb on the head or thorax, or both, of certain fleas." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/ctenidium]
 is_a: BTO:0000518 ! gill
 relationship: part_of BTO:0000282 ! head
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-15T10:22:00Z
 
 [Term]
@@ -43603,7 +43620,7 @@ def: "Normal human skin fibroblast cell line; established from a fetus of a Cauc
 synonym: "Detroit 551 cell" RELATED []
 synonym: "Detroit551 cell" RELATED []
 is_a: BTO:0001619 ! skin fibroblast cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-18T08:46:53Z
 
 [Term]
@@ -43611,14 +43628,14 @@ id: BTO:0005827
 name: FAA-HTC1 cell
 def: "Rat hepatoma cell line." [PMID:1295697]
 is_a: BTO:0000578 ! hepatoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-18T08:52:47Z
 
 [Term]
 id: BTO:0005828
 name: hair follicle epithelium
 relationship: part_of BTO:0000554 ! hair follicle
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-18T09:00:21Z
 
 [Term]
@@ -43626,7 +43643,7 @@ id: BTO:0005829
 name: frontoparietal cortex
 def: "Relating to both frontal and parietal bones of the cranium." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 relationship: part_of BTO:0000233 ! cerebral cortex
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-18T09:11:06Z
 
 [Term]
@@ -43634,7 +43651,7 @@ id: BTO:0005830
 name: leukodystrophy disease specific cell type
 def: "Leukodystrophy is a term for a group of white matter diseases, some familial, characterized by progressive cerebral deterioration usually in early life, and pathologically by primary absence or degeneration of the myelin of the central and peripheral nervous systems with glial reaction; probably related to a defect in lipid metabolism." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 relationship: disease_causes_dysfunction_of BTO:0000236 ! cerebral white matter
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-18T09:29:37Z
 
 [Term]
@@ -43643,7 +43660,7 @@ name: globoid cell leukodystrophy disease specific cell type
 def: "A cell of the lysosomal storage disease beginning in infancy, due to deficiency of beta-galactosidase. Pathologically, there is rapidly progressive cerebral demyelination and large globoid bodies in the white substance." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 synonym: "Krabbe's disease specific cell type" RELATED []
 is_a: BTO:0005830 ! leukodystrophy disease specific cell type
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-18T09:29:06Z
 
 [Term]
@@ -43651,7 +43668,7 @@ id: BTO:0005832
 name: globoid cell
 def: "A large cell of mesodermal origin that is found clustered in the intracranial tissues in globoid cell leukodystrophy." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 is_a: BTO:0005831 ! globoid cell leukodystrophy disease specific cell type
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-18T09:33:22Z
 
 [Term]
@@ -43659,7 +43676,7 @@ id: BTO:0005833
 name: plant gall
 def: "An abnormal growth of plant tissue caused by an organism, such as an insect, mite, or bacterium, or by a wound." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 relationship: develops_from BTO:0001461 ! whole plant
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-18T09:44:05Z
 
 [Term]
@@ -43667,7 +43684,7 @@ id: BTO:0005834
 name: infectious granuloma cell
 def: "One due to a specific microorganism, as tubercle bacilli." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 is_a: BTO:0005835 ! granuloma cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-18T11:31:35Z
 
 [Term]
@@ -43675,7 +43692,7 @@ id: BTO:0005835
 name: granuloma cell
 def: "An imprecise term applied to 1: any small nodular, delimited aggregation of mononuclear inflammatory cells, or 2: a similar collection of modified macrophages resembling epithelial cells, usually surrounded by a rim of lymphocytes, often with multinucleated giant cells." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 relationship: disease_arises_from_structure BTO:0000089 ! blood
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-18T11:34:10Z
 
 [Term]
@@ -43685,7 +43702,7 @@ def: "Human lung stage 4 adenocarcinoma cell line; established from a pleural ef
 synonym: "H-1792 cell" RELATED []
 synonym: "H1792 cell" RELATED []
 is_a: BTO:0001911 ! lung adenocarcinoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-18T11:42:51Z
 
 [Term]
@@ -43695,7 +43712,7 @@ def: "Human stage 3B adenocarcinoma non-small cell lung cancer cell line, establ
 synonym: "H-1944 cell" RELATED []
 synonym: "H1944 cell" RELATED []
 is_a: BTO:0002553 ! non-small cell lung cancer cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-18T11:48:50Z
 
 [Term]
@@ -43704,7 +43721,7 @@ name: head and neck cancer cell
 def: "Head and neck cancer is cancer that starts in the lip, oral cavity, nasal cavity, paranasal sinuses, pharynx, larynx or parotid glands." [Wikipedia:The_Free_Encyclopedia]
 synonym: "head and neck carcinoma cell" RELATED []
 relationship: develops_from BTO:0000282 ! head
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-18T12:15:16Z
 
 [Term]
@@ -43715,7 +43732,7 @@ synonym: "293-VnR cell" RELATED []
 synonym: "293VnR cell" RELATED []
 synonym: "HEK293VnR cell" RELATED []
 relationship: develops_from BTO:0000007 ! HEK-293 cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-19T08:24:44Z
 
 [Term]
@@ -43723,7 +43740,7 @@ id: BTO:0005840
 name: Hs888Lu cell
 def: "Normal human lung fibroblast cell line. The line was derived from normal tissue from a 20 years old male caucasian patient who had osteosarcoma metastatic to the lung." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/, PMID:21512451]
 is_a: BTO:0000161 ! lung fibroblast cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-19T08:34:38Z
 
 [Term]
@@ -43732,7 +43749,7 @@ name: Hunter's organ
 def: "The electric eel has three pairs of abdominal organs that produce electricity: the main organ, the Hunter's organ, and the Sach's organ. These organs are made of electrocytes, lined up so a current of ions can flow through them and stacked so each one adds to a potential difference. The Sach's organ is associated with electrolocation. Inside the organ are many muscle-like cells, called electrocytes. Each cell can only produce 0.15 V, though the organ can transmit a signal of nearly 10 V overall in amplitude at around 25 Hz in frequency. These signals are emitted by the main organ; the Hunter's organ can emit signals at rates of several hundred hertz." [Wiktionary:https\://en.wiktionary.org/wiki/]
 synonym: "Hunter's electric organ" RELATED []
 relationship: part_of BTO:0000376 ! electric organ
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-19T08:55:37Z
 
 [Term]
@@ -43741,21 +43758,21 @@ name: Sach's organ
 def: "The electric eel has three pairs of abdominal organs that produce electricity: the main organ, the Hunter's organ, and the Sach's organ. These organs are made of electrocytes, lined up so a current of ions can flow through them and stacked so each one adds to a potential difference. The Sach's organ is associated with electrolocation. Inside the organ are many muscle-like cells, called electrocytes. Each cell can only produce 0.15 V, though the organ can transmit a signal of nearly 10 V overall in amplitude at around 25 Hz in frequency. These signals are emitted by the main organ; the Hunter's organ can emit signals at rates of several hundred hertz." [Wiktionary:https\://en.wiktionary.org/wiki/]
 synonym: "Sach's electric organ" RELATED []
 relationship: part_of BTO:0000376 ! electric organ
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-19T08:59:05Z
 
 [Term]
 id: BTO:0005843
 name: vaginal epitelial cell
 relationship: part_of BTO:0000422 ! vaginal epithelium
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-19T09:09:44Z
 
 [Term]
 id: BTO:0005844
 name: vaginal epithelial cell line
 relationship: develops_from BTO:0000422 ! vaginal epithelium
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-19T09:10:28Z
 
 [Term]
@@ -43763,7 +43780,7 @@ id: BTO:0005845
 name: HVEC cell
 def: "Human vaginal epithelial cell line." [PMID:22833676]
 is_a: BTO:0005844 ! vaginal epithelial cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-19T09:10:56Z
 
 [Term]
@@ -43773,7 +43790,7 @@ def: "Human neuroblastoma cell line." [PMID:12536080]
 synonym: "IMR 5 cell" RELATED []
 synonym: "IMR5 cell" RELATED []
 relationship: develops_from BTO:0000934 ! IMR-32 cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-19T09:31:26Z
 
 [Term]
@@ -43781,7 +43798,7 @@ id: BTO:0005847
 name: Johnston's organ
 def: "A sense organ in the second antennal segment of insects that responds to movements of the antennal flagellum and serves as a flight-speed indicator." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/Johnston's_organ]
 relationship: part_of BTO:0000074 ! antenna
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-19T09:41:21Z
 
 [Term]
@@ -43790,7 +43807,7 @@ name: K-457 cell
 def: "Human melanoma cell line." [PMID:22249266]
 synonym: "K457 cell" RELATED []
 is_a: BTO:0000849 ! melanoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-19T09:50:26Z
 
 [Term]
@@ -43798,7 +43815,7 @@ id: BTO:0005849
 name: KB-CP.5 cell
 def: "The independent cisplatin resistant derivative of the human epidermoid carcinoma cell line KB-3-1." [PMID:22571463]
 relationship: develops_from BTO:0003918 ! KB-3-1 cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-19T15:12:59Z
 
 [Term]
@@ -43807,21 +43824,21 @@ name: mucinous ovarian adenocarcinoma cell
 def: "Mucinous adenocarcinoma of ovary is a rapidly-growing epithelial tumor that is usually present as a single solid mass within an ovary. Rarely though, it can occur as multiple masses within a single ovary, or may affect both the ovaries as well." [DoveMed:http\://www.dovemed.com/diseases-conditions/mucinous-adenocarcinoma-ovary/]
 synonym: "mucinous ovarian carcinoma cell" RELATED []
 is_a: BTO:0001023 ! ovary cancer cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-19T15:22:18Z
 
 [Term]
 id: BTO:0005851
 name: small cell ovarian carcinoma cell
 is_a: BTO:0001023 ! ovary cancer cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-19T15:27:03Z
 
 [Term]
 id: BTO:0005852
 name: small cell ovarian carcinoma cell line
 is_a: BTO:0000811 ! ovary cancer cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-19T15:27:32Z
 
 [Term]
@@ -43830,7 +43847,7 @@ name: SCCOHT-1 cell
 def: "Small cell ovarian carcinoma of the hypercalcemic type, SCCOHT, represents an aggressive tumor with poor prognosis predominantly affecting young women." [PMID:22581215]
 synonym: "SCCOHT1 cell" RELATED []
 is_a: BTO:0005852 ! small cell ovarian carcinoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-19T15:27:53Z
 
 [Term]
@@ -43838,7 +43855,7 @@ id: BTO:0005854
 name: pronephric tubule
 def: "Any of the segmentally arranged excretory units of the pronephros in the early developing vertebrate embryo. The tubules open into the pronephric duct and communicate with the coelom through a nephrostoma. In humans and the higher vertebrates, the tubules are present only in vestigial form; in lower animals they are functional." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 relationship: part_of BTO:0001541 ! pronephros
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-19T15:39:43Z
 
 [Term]
@@ -43846,7 +43863,7 @@ id: BTO:0005855
 name: SCC-9 cell
 def: "Human tongue squamous cell carcinoma cell line, established from a 25 years old male." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 is_a: BTO:0000786 ! tongue cancer cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-19T15:48:42Z
 
 [Term]
@@ -43854,7 +43871,7 @@ id: BTO:0005856
 name: root apex
 def: "The part of the root where growth and development starts is the root apex. Close to the tip is where the production of new cells and the elongation of the recently-made cells take place." [Plant_Biology:http\://www.plant-biology.com/]
 relationship: part_of BTO:0001188 ! root
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-19T16:02:41Z
 
 [Term]
@@ -43862,7 +43879,7 @@ id: BTO:0005857
 name: root cortex
 def: "The outermost layer of the root of a plant, bounded on the outside by the epidermis and on the inside by the endodermis. In plants, it is composed mostly of differentiated cells, usually large thin-walled parenchyma cells of the ground tissue system. The outer cortical cells often acquire irregularly thickened cell walls, and are called collenchyma cells. Some of the outer cortical cells may contain chloroplasts. It is responsible for the transportation of materials into the central cylinder of the root through diffusion and may also be used for food storage in the form of starch." [Wikipedia:The_Free_Encyclopedia]
 relationship: part_of BTO:0001188 ! root
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-19T16:07:58Z
 
 [Term]
@@ -43870,7 +43887,7 @@ id: BTO:0005858
 name: root pericycle
 def: "The root vascular cylinder is interior to the endodermis and is surrounded by the pericycle, a layer of cells that gives rise to branch roots." [Encyclopedia_Britannica:http\://www.britannica.com/]
 relationship: part_of BTO:0001188 ! root
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-19T16:13:23Z
 
 [Term]
@@ -43878,7 +43895,7 @@ id: BTO:0005859
 name: KNS-42 cell
 def: "Human astrocytic glioma cell line, isolated from the 13th subculture of cells derived from a malignant glioma in 1972 and propagated in vitro for more than 13 years without morphological transformation or contamination by microorganisms." [PMID:2448680]
 is_a: BTO:0000711 ! glioma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-19T16:25:46Z
 
 [Term]
@@ -43886,7 +43903,7 @@ id: BTO:0005860
 name: LA1-55n cell
 def: "Human neuroblastoma cell line, derived from LA1-5s a clonal subline of LA-N-1. LA-N-1 was derived from neuroblastoma cells in the bone marrow of a 2-year-old male with clinical Stage IV neuroblastoma." [Sigma-Aldrich:http\://www.sigmaaldrich.com/]
 relationship: develops_from BTO:0003542 ! LAN-1 cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-19T16:31:33Z
 
 [Term]
@@ -43896,28 +43913,28 @@ def: "Human malignant melanoma cell line, derived from a lymph node metastasis o
 synonym: "SK-MEL24 cell" RELATED []
 synonym: "SKmel-24 cell" RELATED []
 is_a: BTO:0002130 ! SK-MEL cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-19T16:46:11Z
 
 [Term]
 id: BTO:0005862
 name: culture condition:DL-erythro-3,5-diaminohexanoate-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-28T08:48:54Z
 
 [Term]
 id: BTO:0005863
 name: culture condition:ethylamine-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-28T08:49:32Z
 
 [Term]
 id: BTO:0005864
 name: culture condition:N-acetyl-DL-phenylalanine-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-28T08:50:57Z
 
 [Term]
@@ -43929,7 +43946,7 @@ synonym: "U-251 MGsp cell" RELATED []
 synonym: "U-251MG sp cell" RELATED []
 synonym: "U251SP cell" RELATED []
 relationship: develops_from BTO:0002035 ! U-251MG cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-28T11:00:50Z
 
 [Term]
@@ -43937,7 +43954,7 @@ id: BTO:0005866
 name: MDA435/LCC6 cell
 def: "An ascites model of human breast cancer. The MDA435/LCC6 ascites were derived from the oestrogen receptor (ER)-negative, invasive and metastatic MDA-MB-435 cell line." [PMID:8546900]
 relationship: develops_from BTO:0001567 ! MDA-MB-435 cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-28T11:34:39Z
 
 [Term]
@@ -43947,7 +43964,7 @@ def: "MDA435/LCC6 ascites cells transduced with the cDNA of the MDR-1gene." [PMI
 synonym: "LCC6MDR cell" RELATED []
 synonym: "MDA435/LCC6MDR cell" RELATED []
 relationship: develops_from BTO:0005866 ! MDA435/LCC6 cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-28T11:35:38Z
 
 [Term]
@@ -43955,7 +43972,7 @@ id: BTO:0005868
 name: LNCaP-C4 cell
 def: "Androgen receptor-positive, hormone-insensitive LNCaP-derived prostate cancer cell line." [PMID:23997240]
 relationship: develops_from BTO:0001321 ! LNCaP cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-28T11:37:57Z
 
 [Term]
@@ -43963,7 +43980,7 @@ id: BTO:0005869
 name: miracidium
 def: "The free-swimming ciliated first larva of a digenetic trematode that seeks out and penetrates a suitable snail intermediate host in which it develops into a sporocyst." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/miracidium]
 is_a: BTO:0000707 ! larva
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-28T11:39:48Z
 
 [Term]
@@ -43971,7 +43988,7 @@ id: BTO:0005870
 name: MOVAS cell
 def: "Mouse primary vascular aortic smooth muscle cell line; established from a adult mouse of the C57BL/6 strain." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 is_a: BTO:0002290 ! primary cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-28T11:43:03Z
 
 [Term]
@@ -43981,7 +43998,7 @@ def: "A T-cell that has differentiated in bone marrow, and successfully undergon
 synonym: "naive T cell" RELATED []
 synonym: "naive T-cell" RELATED []
 is_a: BTO:0000782 ! T-lymphocyte
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-28T11:44:19Z
 
 [Term]
@@ -43989,14 +44006,14 @@ id: BTO:0005872
 name: NMB cell
 def: "Human neuroblastoma cell line." [PMID:3000378]
 is_a: BTO:0000932 ! neuroblastoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-28T11:46:03Z
 
 [Term]
 id: BTO:0005873
 name: yolk sac cancer cell line
 relationship: develops_from BTO:0001860 ! yolk sac cancer cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-28T11:47:39Z
 
 [Term]
@@ -44005,7 +44022,7 @@ name: NOY-1 cell
 def: "Human ovarian yolk sac tumor cell line." [PMID:18547956]
 synonym: "NOY1 cell" RELATED []
 is_a: BTO:0005873 ! yolk sac cancer cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-28T11:48:04Z
 
 [Term]
@@ -44015,7 +44032,7 @@ def: "KMS-11 cell line knocked out for the MMSET, the multiple myeloma SET domai
 synonym: "KMS11/NTKO cell" RELATED []
 synonym: "NTKO cell" RELATED []
 relationship: develops_from BTO:0003932 ! KMS-11 cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-28T11:56:42Z
 
 [Term]
@@ -44026,7 +44043,7 @@ synonym: "KMS-11 TKO cell" RELATED []
 synonym: "KMS11/TKO cell" RELATED []
 synonym: "TKO cell" RELATED []
 relationship: develops_from BTO:0003932 ! KMS-11 cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-28T11:58:15Z
 
 [Term]
@@ -44034,7 +44051,7 @@ id: BTO:0005877
 name: papillary adenocarcinoma cell
 def: "An adenocarcinoma containing fingerlike processes of vascular connective tissue covered by neoplastic epithelium, projecting into cysts or the cavity of glands or follicles; occurs most frequently in the ovary and thyroid gland." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 is_a: BTO:0000604 ! adenocarcinoma cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-28T12:01:09Z
 
 [Term]
@@ -44044,7 +44061,7 @@ def: "Human pancreatic adenocarcinoma cell line; established in 1985 from the li
 synonym: "PaTu-8988T cell" RELATED []
 synonym: "PaTu8988T cell" RELATED []
 is_a: BTO:0001521 ! pancreatic adenocarcinoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-28T12:03:06Z
 
 [Term]
@@ -44053,7 +44070,7 @@ name: PA-TU-8988S cell
 def: "Human pancreatic adenocarcinoma cell line; established in 1985 from the liver metastasis of a primary pancreatic adenocarcinoma from a 64-year-old woman; sister cell line of PA-TU-8988T." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 synonym: "PaTu8988S cell" RELATED []
 is_a: BTO:0001521 ! pancreatic adenocarcinoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-28T12:03:49Z
 
 [Term]
@@ -44062,7 +44079,7 @@ name: Res-186 cell
 def: "Human paediatric glioma cell line." [PMID:20935218]
 synonym: "Res186 cell" RELATED []
 is_a: BTO:0000711 ! glioma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-28T12:05:46Z
 
 [Term]
@@ -44071,7 +44088,7 @@ name: Res-259 cell
 def: "Human paediatric glioma cell line." [PMID:20935218]
 synonym: "Res259 cell" RELATED []
 is_a: BTO:0000711 ! glioma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-28T12:06:32Z
 
 [Term]
@@ -44081,7 +44098,7 @@ def: "Complex sensillum in insects consisting of a bundle of sensory cells whose
 synonym: "scolophore" RELATED []
 synonym: "scolopophore" RELATED []
 is_a: BTO:0001237 ! sensillum
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-28T12:07:58Z
 
 [Term]
@@ -44091,7 +44108,7 @@ def: "Metastatic patient-derived human melanoma cell line." [PMID:24879157]
 synonym: "UACC 3291 cell" RELATED []
 synonym: "UACC3291 cell" RELATED []
 is_a: BTO:0000849 ! melanoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-28T12:30:35Z
 
 [Term]
@@ -44099,7 +44116,7 @@ id: BTO:0005884
 name: scolopale cap cell
 def: "A scolopidium is a composition of three cells, a scolopale cap cell which caps the scolopale cell, and a bipolar sensory nerve cell. Scolopidia are sensitive to things like sound (vibrations of the air) or substrate vibrations (feeling vibrations on a leaf, for instance) depending on the structure of the overall sense organ in which they reside." [Wikipedia:The_Free_Encyclopedia]
 relationship: part_of BTO:0005882 ! scolopidium
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-28T12:11:39Z
 
 [Term]
@@ -44107,7 +44124,7 @@ id: BTO:0005885
 name: scolopale cell
 def: "A scolopidium is a composition of three cells, a scolopale cap cell which caps the scolopale cell, and a bipolar sensory nerve cell. Scolopidia are sensitive to things like sound (vibrations of the air) or substrate vibrations (feeling vibrations on a leaf, for instance) depending on the structure of the overall sense organ in which they reside." [Wikipedia:The_Free_Encyclopedia]
 relationship: part_of BTO:0005882 ! scolopidium
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-28T12:12:45Z
 
 [Term]
@@ -44116,7 +44133,7 @@ name: seedpod
 def: "A seed pod is an elongated, two-sided vessel that contain several fertilized seeds. It is a dehiscent fruit or pedicarp - the pod splits open when the seeds are mature. Beans and peas are some plants that have pods." [Plant_Glossary:http\://www.enchantedlearning.com/]
 synonym: "pod" RELATED []
 is_a: BTO:0000486 ! fruit
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-28T12:14:08Z
 
 [Term]
@@ -44126,7 +44143,7 @@ def: "Swine kidney cell line." [PMID:4336054]
 synonym: "SK6 cell" RELATED []
 synonym: "Swine Kidney-6 cell" RELATED []
 is_a: BTO:0000067 ! kidney cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-28T12:16:16Z
 
 [Term]
@@ -44135,7 +44152,7 @@ name: UW-479 cell
 def: "Human paediatric glioma cell line." [PMID:20935218]
 synonym: "UW479 cell" RELATED []
 is_a: BTO:0000711 ! glioma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-28T12:32:52Z
 
 [Term]
@@ -44143,7 +44160,7 @@ id: BTO:0005889
 name: WIF-B cell
 def: "A highly differentiated and polarized rat hepatoma/human fibroblast hybrid, which forms abundant bile canalicular structures." [PMID:16109175]
 is_a: BTO:0000578 ! hepatoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-28T12:34:27Z
 
 [Term]
@@ -44151,7 +44168,7 @@ id: BTO:0005890
 name: xylem parenchyma cell
 def: "Xylem tissue features thin-walled, unspecialized parenchyma cells, for the storage of various substances." [Encyclopedia_Britannica:http\://www.britannica.com/]
 relationship: part_of BTO:0001468 ! xylem
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-28T12:35:52Z
 
 [Term]
@@ -44160,7 +44177,7 @@ name: sporocyst
 def: "1. A larval form of digenetic trematode (fluke) that develops in the body of its molluscan intermediate host, usually a snail; the sporocyst forms a simple saclike structure with germinal cells that bud off internally and develop into other larval types that continue this process of larval multiplication (considered to be a form of polyembryony). 2. A secondary cyst that develops within the oocyst of Coccidia, a group of sporozoans that includes many of the most important disease agents of domestic animals and fowl; the sporocyst develops from a sporoblast and produces within itself one or several sporozoites, the infective agents for infection and multiplication in the next host." [Medical_Dictionary:http\://www.medilexicon.com/]
 is_a: BTO:0000707 ! larva
 is_a: BTO:0001773 ! oocyst
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-28T14:07:28Z
 
 [Term]
@@ -44169,7 +44186,7 @@ name: SVOG-3e cell
 def: "Immortalized human granulosa cell line." [PMID:26408257]
 synonym: "SVOG3e cell" RELATED []
 is_a: BTO:0002285 ! granulosa cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-28T14:14:48Z
 
 [Term]
@@ -44180,7 +44197,7 @@ synonym: "distal nonpigmented epithelium" RELATED []
 synonym: "inner nonpigmented epithelium" RELATED []
 synonym: "non-pigmented ciliary epithelium" RELATED []
 relationship: part_of BTO:0001770 ! ciliary epithelium
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-29T09:09:21Z
 
 [Term]
@@ -44190,7 +44207,7 @@ def: "The ciliary epithelium is composed of two layers juxtaposed, the proximal 
 synonym: "outer pigmented epithelium" RELATED []
 synonym: "proximal pigmented epithelium" RELATED []
 relationship: part_of BTO:0001770 ! ciliary epithelium
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-04-29T09:10:33Z
 
 [Term]
@@ -44200,7 +44217,7 @@ def: "Metastatic patient-derived human melanoma cell line." [PMID:24879157]
 synonym: "UACC 1308 cell" RELATED []
 synonym: "UACC1308 cell" RELATED []
 is_a: BTO:0000849 ! melanoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-05-02T10:16:47Z
 
 [Term]
@@ -44210,7 +44227,7 @@ def: "Metastatic patient-derived human melanoma cell line." [PMID:24879157]
 synonym: "UACC 1940 cell" RELATED []
 synonym: "UACC1940 cell" RELATED []
 is_a: BTO:0000849 ! melanoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-05-02T10:20:17Z
 
 [Term]
@@ -44220,7 +44237,7 @@ def: "Metastatic patient-derived human melanoma cell line." [PMID:24879157]
 synonym: "UACC 2534 cell" RELATED []
 synonym: "UACC2534 cell" RELATED []
 is_a: BTO:0000849 ! melanoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-05-02T10:21:44Z
 
 [Term]
@@ -44230,7 +44247,7 @@ def: "Metastatic patient-derived human melanoma cell line." [PMID:24879157]
 synonym: "UACC 502 cell" RELATED []
 synonym: "UACC502 cell" RELATED []
 is_a: BTO:0000849 ! melanoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-05-02T10:23:42Z
 
 [Term]
@@ -44240,14 +44257,14 @@ def: "Metastatic patient-derived human melanoma cell line." [PMID:24879157]
 synonym: "UACC 91 cell" RELATED []
 synonym: "UACC91 cell" RELATED []
 is_a: BTO:0000849 ! melanoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-05-02T10:24:49Z
 
 [Term]
 id: BTO:0005900
 name: culture condition:n-hexadecane grown-cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-05-02T10:26:00Z
 
 [Term]
@@ -44255,7 +44272,7 @@ id: BTO:0005901
 name: byssus retractor muscle
 synonym: "byssal retractor muscle" RELATED []
 is_a: BTO:0001262 ! soft body part
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-05-02T10:27:19Z
 
 [Term]
@@ -44263,7 +44280,7 @@ id: BTO:0005902
 name: DiFi cell
 def: "Human colorectal cancer cell line; established from a familial adenomatous polyposis patient with extracolonic features characteristic of the Gardner syndrome." [PMID:8385096]
 is_a: BTO:0001616 ! colorectal cancer cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-06-14T14:42:18Z
 
 [Term]
@@ -44273,7 +44290,7 @@ def: "DMS 273 was initiated in 1978 from the pleural fluid specimen from a 50 ye
 synonym: "DMS 273 cell" RELATED []
 synonym: "DMS273 cell" RELATED []
 is_a: BTO:0002553 ! non-small cell lung cancer cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-06-14T14:48:45Z
 
 [Term]
@@ -44282,7 +44299,7 @@ name: EM-2 cell
 def: "Human chronic myeloid leukemia cell line in blast crisis; established from the bone marrow of  5-year-old Caucasian girl with Philadelphia chromosome positive chronic myeloid leukemia in second relapse in 1980, after bone marrow transplantation day +28; sister cell line of EM-3." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 synonym: "EM2 cell" RELATED []
 is_a: BTO:0002580 ! chronic myeloid leukemia cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-06-14T14:57:37Z
 
 [Term]
@@ -44291,7 +44308,7 @@ name: EM-3 cell
 def: "Human chronic myeloid leukemia cell line in blast crisis; established from the bone marrow of  5-year-old Caucasian girl with Philadelphia chromosome positive chronic myeloid leukemia in second relapse in 1980, after bone marrow transplantation day +47; sister cell line of EM-2." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 synonym: "EM3 cell" RELATED []
 is_a: BTO:0002580 ! chronic myeloid leukemia cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-06-14T14:59:34Z
 
 [Term]
@@ -44300,7 +44317,7 @@ name: FU-97 cell
 def: "Human stomach cancer cell line." [Cellbank:http\://cellbank.nibiohn.go.jp//legacy/celldata/]
 synonym: "FU97 cell" RELATED []
 is_a: BTO:0000787 ! gastric cancer cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-06-14T15:03:59Z
 
 [Term]
@@ -44308,7 +44325,7 @@ id: BTO:0005907
 name: H-MESO-1 cell
 def: "Human malignant mesothelioma cell line." [PMID:3555770]
 is_a: BTO:0002424 ! mesothelioma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-06-14T15:06:24Z
 
 [Term]
@@ -44317,7 +44334,7 @@ name: IM-95 cell
 def: "Human gastric adenocarcinoma cell line; established from a 63-years old japanese male patient with moderately differentiated adenocarcinoma of the stomach." [Cellbank:http\://cellbank.nibiohn.go.jp//legacy/celldata/]
 synonym: "IM95 cell" RELATED []
 is_a: BTO:0002380 ! gastric adenocarcinoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-06-14T16:17:50Z
 
 [Term]
@@ -44325,7 +44342,7 @@ id: BTO:0005909
 name: JURL-MK1 cell
 def: "Human chronic myeloid leukemia in blast crisis; established from the peripheral blood of a 73-year-old man with chronic myeloid leukemia in blast crisis in 1993; cells carry the Philadelphia chromosome; JURL-MK1 and JURL-MK2 are sister cell lines derived from the same patient." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 is_a: BTO:0002580 ! chronic myeloid leukemia cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-06-14T16:23:35Z
 
 [Term]
@@ -44333,7 +44350,7 @@ id: BTO:0005910
 name: JURL-MK2 cell
 def: "Human chronic myeloid leukemia in blast crisis; established from the peripheral blood of a 73-year-old man with chronic myeloid leukemia in blast crisis in 1993; cells carry the Philadelphia chromosome; JURL-MK1 and JURL-MK2 are sister cell lines derived from the same patient." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 is_a: BTO:0002580 ! chronic myeloid leukemia cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-06-14T16:30:08Z
 
 [Term]
@@ -44345,7 +44362,7 @@ synonym: "KM 2012 cell" RELATED []
 synonym: "KM 20L2 cell" RELATED []
 synonym: "KM20L2 cell" RELATED []
 relationship: develops_from BTO:0000182 ! HT-29 cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-06-14T16:33:15Z
 
 [Term]
@@ -44354,7 +44371,7 @@ name: LP-1 cell
 def: "Human multiple myeloma cell line; established from the peripheral blood of a 56-year-old woman with multiple myeloma in leukemic transformation in 1986." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 synonym: "LP1 cell" RELATED []
 is_a: BTO:0000727 ! multiple myeloma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-06-14T17:15:30Z
 
 [Term]
@@ -44363,7 +44380,7 @@ name: MEC-1 cell
 def: "Human chronic B cell leukemia cell line; established in 1993 from the peripheral blood of a 61-year-old Caucasian man with chronic B cell leukemia; serial sister cell line of MEC-2." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 synonym: "MEC1 cell" RELATED []
 is_a: BTO:0000741 ! lymphocytic leukemia cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-06-14T17:24:00Z
 
 [Term]
@@ -44372,7 +44389,7 @@ name: MEC-2 cell
 def: "Human chronic B cell leukemia cell line; established in 1993 from the peripheral blood of a 61-year-old Caucasian man with chronic B cell leukemia; serial sister cell line of MEC-1." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 synonym: "MEC2 cell" RELATED []
 is_a: BTO:0000741 ! lymphocytic leukemia cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-06-14T17:26:56Z
 
 [Term]
@@ -44383,7 +44400,7 @@ synonym: "H-727 cell" RELATED []
 synonym: "H727 cell" RELATED []
 synonym: "NCIH727 cell" RELATED []
 is_a: BTO:0002553 ! non-small cell lung cancer cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-06-16T13:30:23Z
 
 [Term]
@@ -44392,7 +44409,7 @@ name: NOMO-1 cell
 def: "Human acute myeloid leukemia cell line; established from the bone marrow of a 31-year-old woman with acute myeloid leukemia at 2nd relapse." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 synonym: "NOMO1 cell" RELATED []
 is_a: BTO:0001883 ! acute myeloid leukemia cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-06-16T13:39:35Z
 
 [Term]
@@ -44401,7 +44418,7 @@ name: NUGC-4 cell
 def: "Human gastric cancer cell line." [PMID:9052764]
 synonym: "NUGC4 cell" RELATED []
 is_a: BTO:0000787 ! gastric cancer cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-06-16T13:52:40Z
 
 [Term]
@@ -44410,7 +44427,7 @@ name: OCUM-1 cell
 def: "Human gastric cancer cell line,  derived from Borrmann type IV tumor of the stomach." [PMID:1961183]
 synonym: "OCUM1 cell" RELATED []
 is_a: BTO:0000787 ! gastric cancer cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-06-16T13:55:20Z
 
 [Term]
@@ -44419,7 +44436,7 @@ name: OPM-2 cell
 def: "Human multiple myeloma established from the peripheral blood of a 56-year-old woman with multiple myeloma in leukemic phase in 1982." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 synonym: "OPM2 cell" RELATED []
 is_a: BTO:0000727 ! multiple myeloma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-06-16T13:58:17Z
 
 [Term]
@@ -44427,14 +44444,14 @@ id: BTO:0005920
 name: laryngeal cancer cell line
 is_a: BTO:0000955 ! laryngeal cell line
 relationship: develops_from BTO:0001625 ! laryngeal cancer cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-06-16T15:17:28Z
 
 [Term]
 id: BTO:0005921
 name: laryngeal squamous cell carcinoma cell line
 is_a: BTO:0005920 ! laryngeal cancer cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-06-16T15:18:23Z
 
 [Term]
@@ -44444,7 +44461,7 @@ def: "Human laryngeal squamous cell carcinoma cell line; established from Korean
 synonym: "SNU 1076 cell" RELATED []
 synonym: "SNU1076 cell" RELATED []
 is_a: BTO:0005921 ! laryngeal squamous cell carcinoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-06-16T15:18:41Z
 
 [Term]
@@ -44454,7 +44471,7 @@ def: "Human laryngeal squamous cell carcinoma cell line; established from Korean
 synonym: "SNU 1214 cell" RELATED []
 synonym: "SNU1214 cell" RELATED []
 is_a: BTO:0005921 ! laryngeal squamous cell carcinoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-06-16T15:20:45Z
 
 [Term]
@@ -44464,7 +44481,7 @@ def: "Human laryngeal squamous cell carcinoma cell line; established from Korean
 synonym: "SNU 1066 cell" RELATED []
 synonym: "SNU1066 cell" RELATED []
 is_a: BTO:0005921 ! laryngeal squamous cell carcinoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-06-16T15:20:51Z
 
 [Term]
@@ -44474,7 +44491,7 @@ def: "Human laryngeal squamous cell carcinoma cell line; established from Korean
 synonym: "SNU 899 cell" RELATED []
 synonym: "SNU899 cell" RELATED []
 is_a: BTO:0005921 ! laryngeal squamous cell carcinoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-06-16T15:20:55Z
 
 [Term]
@@ -44484,7 +44501,7 @@ def: "Human laryngeal squamous cell carcinoma cell line; established from Korean
 synonym: "SNU 585 cell" RELATED []
 synonym: "SNU585 cell" RELATED []
 is_a: BTO:0005921 ! laryngeal squamous cell carcinoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-06-16T15:20:59Z
 
 [Term]
@@ -44494,7 +44511,7 @@ def: "Human laryngeal squamous cell carcinoma cell line; established from Korean
 synonym: "SNU 46 cell" RELATED []
 synonym: "SNU46 cell" RELATED []
 is_a: BTO:0005921 ! laryngeal squamous cell carcinoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-06-16T15:23:47Z
 
 [Term]
@@ -44503,7 +44520,7 @@ name: PL-21 cell
 def: "Human acute myeloid leukemia cell line; established from the peripheral blood of a 24-year-old man with refractory acute promyelocytic leukemia after mediastinal granulocytic sarcoma." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 synonym: "PL21 cell" RELATED []
 is_a: BTO:0001883 ! acute myeloid leukemia cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-06-16T15:26:56Z
 
 [Term]
@@ -44511,7 +44528,7 @@ id: BTO:0005929
 name: SCH cell
 def: "Human gastric choriocarcinoma cell line." [PMID:1170940]
 is_a: BTO:0001575 ! choriocarcinoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-06-16T15:30:35Z
 
 [Term]
@@ -44523,7 +44540,7 @@ synonym: "C3H/10T1/2 CL8 cell" RELATED []
 synonym: "C3H/10T1/2-clone8 cell" RELATED []
 synonym: "C3H10T1/2CL8 cell" RELATED []
 relationship: develops_from BTO:0004058 ! C3H10T1/2 cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-06-24T11:09:52Z
 
 [Term]
@@ -44535,7 +44552,7 @@ synonym: "CCRF-CEM C2 cell" RELATED []
 synonym: "CEM/C2 cell" RELATED []
 synonym: "CEMC2 cell" RELATED []
 relationship: develops_from BTO:0000736 ! CCRF-CEM cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-06-24T13:05:10Z
 
 [Term]
@@ -44543,7 +44560,7 @@ id: BTO:0005932
 name: SUM cell
 def: "Ten SUM cell lines derived in Steve Ethiers lab while present at the University of Michigan are available for purchase. Each cell line, from a single patient, represents a different subtype of breast cancer. All of the currently known oncogenes with altered expression patterns in breast cancer, in various combinations, are represented and characterized in the SUM lines." [Asterand_Bioscience:http\://solutions.asterand.com/]
 is_a: BTO:0000356 ! breast cancer cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-07-14T10:18:56Z
 
 [Term]
@@ -44557,7 +44574,7 @@ synonym: "SUM1315 cell" RELATED []
 synonym: "SUM1315-MO2 cell" RELATED []
 synonym: "SUM1315MO2 cell" RELATED []
 is_a: BTO:0005932 ! SUM cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-07-14T10:51:45Z
 
 [Term]
@@ -44565,14 +44582,14 @@ id: BTO:0005934
 name: axial nerve cord
 def: "Six main nerve centers lie in the arm of an octopus and are responsible for the performance of these sets of muscles. The axial nerve cord is by far the most important motor and integrative center of the arm." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0001656 ! nerve cord
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-22T08:43:01Z
 
 [Term]
 id: BTO:0005935
 name: culture condition:crotonate-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-22T09:07:53Z
 
 [Term]
@@ -44583,7 +44600,7 @@ comment: Is a synonym of CWR22-Rv1 cell.
 synonym: "CWR-R1 cell" RELATED []
 synonym: "R1 cell" RELATED []
 is_obsolete: true
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-22T09:29:39Z
 
 [Term]
@@ -44591,7 +44608,7 @@ id: BTO:0005937
 name: intestinal epithelial cell
 synonym: "intestinal epithelium cell" RELATED []
 relationship: part_of BTO:0000781 ! intestinal epithelium
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-22T09:53:46Z
 
 [Term]
@@ -44599,7 +44616,7 @@ id: BTO:0005938
 name: pharyngeal tooth
 def: "Pharyngeal teeth are teeth in the pharyngeal arch of the throat of cyprinids, suckers, and a number of other fish species otherwise lacking teeth." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0000397 ! tooth
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-22T10:14:45Z
 
 [Term]
@@ -44607,7 +44624,7 @@ id: BTO:0005939
 name: gynoecial nectary
 def: "There, floral nectar is secreted from some part of the ovary tissue." [Pollination_and_Floral_Ecology:Pat_Willmer]
 is_a: BTO:0000357 ! nectary
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-22T14:43:36Z
 
 [Term]
@@ -44615,7 +44632,7 @@ id: BTO:0005940
 name: sepal nectary
 def: "This kind of nectary is located on a sepal or an equivalent on a calyx." [Pollination_and_Floral_Ecology:Pat_Willmer]
 is_a: BTO:0000357 ! nectary
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-22T14:49:51Z
 
 [Term]
@@ -44623,7 +44640,7 @@ id: BTO:0005941
 name: staminal nectary
 def: "There all or part of a stamen is nectariferous, either the filament or the anthers or both being involved." [Pollination_and_Floral_Ecology:Pat_Willmer]
 is_a: BTO:0000357 ! nectary
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-22T14:51:04Z
 
 [Term]
@@ -44631,7 +44648,7 @@ id: BTO:0005942
 name: petal nectary
 def: "This kind of nectary is formed from part or all of a petal. This type is common in the buttercup family, Ranunculaceae." [Pollination_and_Floral_Ecology:Pat_Willmer]
 is_a: BTO:0000357 ! nectary
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-22T14:52:18Z
 
 [Term]
@@ -44639,7 +44656,7 @@ id: BTO:0005943
 name: mesenteric adipose tissue
 def: "Visceral fat is composed of several adipose depots, including mesenteric, epididymal white adipose tissue EWAT, and perirenal depots." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0001487 ! adipose tissue
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-22T14:56:43Z
 
 [Term]
@@ -44648,7 +44665,7 @@ name: epididymal white adipose tissue
 def: "Visceral fat is composed of several adipose depots, including mesenteric, epididymal white adipose tissue EWAT, and perirenal depots." [Wikipedia:The_Free_Encyclopedia]
 synonym: "EWAT cell" RELATED []
 is_a: BTO:0001456 ! white adipose tissue
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-22T14:57:43Z
 
 [Term]
@@ -44656,7 +44673,7 @@ id: BTO:0005945
 name: perirenal adipose tissue
 def: "Visceral fat is composed of several adipose depots, including mesenteric, epididymal white adipose tissue EWAT, and perirenal depots." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0001487 ! adipose tissue
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-22T14:58:39Z
 
 [Term]
@@ -44664,7 +44681,7 @@ id: BTO:0005946
 name: sublingual squamous cell carcinoma cell
 is_a: BTO:0001289 ! squamous cell carcinoma cell
 is_a: BTO:0002773 ! salivary gland cancer cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-22T15:01:50Z
 
 [Term]
@@ -44672,7 +44689,7 @@ id: BTO:0005947
 name: sublingual squamous cell carcinoma cell line
 is_a: BTO:0002024 ! squamous cell carcinoma cell line
 is_a: BTO:0003645 ! salivary gland tumor cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-22T15:05:06Z
 
 [Term]
@@ -44682,7 +44699,7 @@ def: "HO-1-u-1 is a human tumor cell line established from human sublingual squa
 synonym: "Ho-1-u-1 cell" RELATED []
 synonym: "Ueda-1 cell" RELATED []
 is_a: BTO:0005947 ! sublingual squamous cell carcinoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-22T15:06:16Z
 
 [Term]
@@ -44691,7 +44708,7 @@ name: glioblastoma multiforme cell line
 def: "Glioblastoma multiforme is the most aggressive of the gliomas, a collection of tumors arising from glia or their precursors within the central nervous system." [PMID:10841526]
 synonym: "GBM cell" RELATED []
 is_a: BTO:0001530 ! glioblastoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-22T15:17:27Z
 
 [Term]
@@ -44701,7 +44718,7 @@ def: "Primary human adult GBM line derived from a tumor resected at initial diag
 synonym: "BT 145 cell" RELATED []
 synonym: "BT145 cell" RELATED []
 is_a: BTO:0005949 ! glioblastoma multiforme cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-22T15:20:24Z
 
 [Term]
@@ -44711,7 +44728,7 @@ def: "Primary human adult GBM line derived from a tumor resected at initial diag
 synonym: "BT 159 cell" RELATED []
 synonym: "BT159 cell" RELATED []
 is_a: BTO:0005949 ! glioblastoma multiforme cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-22T15:24:41Z
 
 [Term]
@@ -44721,7 +44738,7 @@ def: "Primary human pediatric GBM line derived from a supratentorial GBM resecte
 synonym: "BT 245 cell" RELATED []
 synonym: "BT245 cell" RELATED []
 is_a: BTO:0005949 ! glioblastoma multiforme cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-22T15:25:25Z
 
 [Term]
@@ -44731,7 +44748,7 @@ def: "Primary human adult GBM line derived from a tumor resected at initial diag
 synonym: "BT 172 cell" RELATED []
 synonym: "BT172 cell" RELATED []
 is_a: BTO:0005949 ! glioblastoma multiforme cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-22T15:26:13Z
 
 [Term]
@@ -44741,7 +44758,7 @@ def: "Primary human pediatric GBM line derived from previously irradiated diffus
 synonym: "DIPG 6 cell" RELATED []
 synonym: "DIPG6 cell" RELATED []
 is_a: BTO:0005949 ! glioblastoma multiforme cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-22T15:27:56Z
 
 [Term]
@@ -44751,7 +44768,7 @@ def: "Primary human pediatric GBM line derived from previously irradiated diffus
 synonym: "DIPG 4 cell" RELATED []
 synonym: "DIPG4 cell" RELATED []
 is_a: BTO:0005949 ! glioblastoma multiforme cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-22T15:28:01Z
 
 [Term]
@@ -44760,7 +44777,7 @@ name: UMNSAH/DF-1 cell
 def: "Chicken, gallus gallus, embryonic fibroblast cell line. A spontaneously immortalized chicken cell line derived from 10 day old East Lansing Line eggs." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 synonym: "DF-1 cell" RELATED []
 is_a: BTO:0001958 ! embryonic fibroblast cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-24T09:16:09Z
 
 [Term]
@@ -44768,7 +44785,7 @@ id: BTO:0005957
 name: extrastaminal nectary
 def: "Nectary located outside the stamen whorl of a flower." [Wiktionary:https\://en.wiktionary.org/wiki/]
 is_a: BTO:0000357 ! nectary
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-24T09:24:37Z
 
 [Term]
@@ -44776,7 +44793,7 @@ id: BTO:0005958
 name: ovarian follicular epithelium
 def: "The ovarian follicular epithelium originates as a few flattened cells derived from the germinal epithelium. The primitive role of the follicular cells appears to be the secretion of the yolk-forming material onto or into the oocyte. Evidence from mammals indicates that the follicular cells may also have a role in converting substances produced elsewhere into female hormones, or estrogens." [Encyclopedia_Britannica:http\://www.britannica.com/]
 is_a: BTO:0000475 ! ovarian follicle
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-24T09:28:04Z
 
 [Term]
@@ -44784,7 +44801,7 @@ id: BTO:0005959
 name: thyroid follicular epithelial cell
 def: "A cell lining a follicle such as that of the thyroid gland." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 relationship: part_of BTO:0004708 ! thyroid follicle
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-24T09:31:44Z
 
 [Term]
@@ -44792,7 +44809,7 @@ id: BTO:0005960
 name: ovarian follicular epithelial cell
 def: "A cell lining a follicle such as that of the thyroid gland." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 relationship: part_of BTO:0005958 ! ovarian follicular epithelium
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-24T09:32:36Z
 
 [Term]
@@ -44800,7 +44817,7 @@ id: BTO:0005961
 name: GM03440 cell
 def: "Human skin fibroblast cell line; established from a skin biopsy of the leg of a caucasian male." [Coriell_Institute_for_Medical_Research:https\://catalog.coriell.org/]
 is_a: BTO:0001619 ! skin fibroblast cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-24T09:41:58Z
 
 [Term]
@@ -44810,7 +44827,7 @@ def: "A mutant cell line derived from mouse melanoma MEB-4 cells, is deficient i
 synonym: "GM95 cell" RELATED []
 synonym: "MEC-4 cell" RELATED []
 relationship: develops_from BTO:0001219 ! MEB-4 cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-24T09:48:20Z
 
 [Term]
@@ -44819,7 +44836,7 @@ name: HCC-70 cell
 def: "Human breast mammary duct carcinoma cell line." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 synonym: "HCC70 cell" RELATED []
 is_a: BTO:0004086 ! mammary gland tumor cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-24T16:03:39Z
 
 [Term]
@@ -44828,7 +44845,7 @@ name: HIB-1B cell
 def: "Cell line, derived from a brown fat tumor of a transgenic mouse, capable of expressing the brown fat-specific mitochondrial uncoupling protein." [PMID:8175918]
 synonym: "HIB 1B cell" RELATED []
 is_a: BTO:0003452 ! adipocyte cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-24T16:13:40Z
 
 [Term]
@@ -44843,7 +44860,7 @@ synonym: "L02 cell" RELATED []
 synonym: "LO-2 cell" RELATED []
 synonym: "LO2 cell" RELATED []
 relationship: develops_from BTO:0000567 ! HeLa cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-24T16:43:44Z
 
 [Term]
@@ -44853,7 +44870,7 @@ def: "Human classic small cell lung cancer cell line; established from a 50 year
 synonym: "H-1688 cell" RELATED []
 synonym: "H1688 cell" RELATED []
 is_a: BTO:0002206 ! small cell lung cancer cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-24T16:46:09Z
 
 [Term]
@@ -44863,7 +44880,7 @@ def: "Human duodenal adenocarcinoma cell line." [ATCC_American_Cell_Type_Culture
 synonym: "HuTu 80 cell" RELATED []
 synonym: "HuTu80 cell" RELATED []
 is_a: BTO:0001913 ! colonic adenocarcinoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-24T17:24:40Z
 
 [Term]
@@ -44872,7 +44889,7 @@ name: KOSC-2 cell
 def: "Human oral cancer cell line." [PMID:8314315]
 synonym: "KOSC2 cell" RELATED []
 is_a: BTO:0002027 ! oral cancer cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-24T17:06:00Z
 
 [Term]
@@ -44881,7 +44898,7 @@ name: KOSC-3 cell
 def: "Human oral cancer cell line." [PMID:8314315]
 synonym: "KOSC3 cell" RELATED []
 is_a: BTO:0002027 ! oral cancer cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-24T17:06:43Z
 
 [Term]
@@ -44892,7 +44909,7 @@ synonym: "LCC-9 cell" RELATED []
 synonym: "LCC9 cell" RELATED []
 synonym: "MCF7/LCC9 cell" RELATED []
 is_a: BTO:0000093 ! MCF-7 cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-25T09:26:01Z
 
 [Term]
@@ -44900,7 +44917,7 @@ id: BTO:0005971
 name: culture condition:McCoys 5A medium-grown cell
 def: "McCoy's 5A medium was originally developed for the growth of Novikoff hepatoma cells. As modified by Iwakata and Grace, the increased levels of glucose, vitamins and peptone make McCoy's 5A a good general purpose medium for both primary, and established cell lines. Cells from biopsies (liver, intestine, skin, testes, bone marrow, spleen, lung and gingiva) have successfully been cultivated in this medium." [Merck_Millipore:http\://www.biochrom.de/en/products/cell-culture-media/]
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-25T09:40:58Z
 
 [Term]
@@ -44909,7 +44926,7 @@ name: MI8-5 CHO cell
 def: "Glc-P-Dol-dependent glucosyltransferase  I deficient CHO cell line." [PMID:15175254]
 synonym: "MI8-5 cell" RELATED []
 relationship: develops_from BTO:0000246 ! CHO cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-25T09:48:32Z
 
 [Term]
@@ -44917,7 +44934,7 @@ id: BTO:0005973
 name: Muellerian body
 def: "One of the minute nitrogenous and oily glands on the leaves of a myrmecophyte, Cecropia adenopus serving as food for the symbiotic ants that inhabit the plant." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/muellerian_body]
 is_a: BTO:0005418 ! plant oil gland
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-25T09:56:04Z
 
 [Term]
@@ -44927,7 +44944,7 @@ def: "Human small cell lung cancer cell line; established in April 1985 from a p
 synonym: "H-1048 cell" RELATED []
 synonym: "H1048 cell" RELATED []
 is_a: BTO:0002206 ! small cell lung cancer cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-25T11:36:07Z
 
 [Term]
@@ -44937,7 +44954,7 @@ def: "Human classic small cell lung cancer cell line; established from a stage L
 synonym: "H-1672 cell" RELATED []
 synonym: "H1672 cell" RELATED []
 is_a: BTO:0002206 ! small cell lung cancer cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-25T11:40:05Z
 
 [Term]
@@ -44947,7 +44964,7 @@ def: "Human small cell lung cancer cell line; established in June 1988 from a st
 synonym: "H-1963 cell" RELATED []
 synonym: "H1963 cell" RELATED []
 is_a: BTO:0002206 ! small cell lung cancer cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-25T11:43:16Z
 
 [Term]
@@ -44957,7 +44974,7 @@ def: "Human small cell lung cancer cell line; established in September 1988 from
 synonym: "H-2029 cell" RELATED []
 synonym: "H2029 cell" RELATED []
 is_a: BTO:0002206 ! small cell lung cancer cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-25T11:45:01Z
 
 [Term]
@@ -44967,7 +44984,7 @@ def: "Human small cell lung cancer cell line; established in April 1989 from a s
 synonym: "H-2171 cell" RELATED []
 synonym: "H2171 cell" RELATED []
 is_a: BTO:0002206 ! small cell lung cancer cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-25T11:48:39Z
 
 [Term]
@@ -44977,14 +44994,14 @@ def: "Human classic small cell lung cancer cell line; established in June 1984 f
 synonym: "H-740 cell" RELATED []
 synonym: "H740 cell" RELATED []
 is_a: BTO:0002206 ! small cell lung cancer cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-25T11:51:58Z
 
 [Term]
 id: BTO:0005980
 name: nectary parenchyma
 is_a: BTO:0000357 ! nectary
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-25T11:56:11Z
 
 [Term]
@@ -44993,7 +45010,7 @@ name: auditory capsule
 def: "The cartilage capsule surrounding the internal ear mechanism; in elasmobranchs, it remains cartilaginous in the adult; in the embryos of higher vertebrates, it is cartilaginous at first but later becomes bony, at approximately 23 weeks in humans." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 synonym: "otic capsule" RELATED []
 relationship: part_of BTO:0000630 ! inner ear
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-25T12:12:00Z
 
 [Term]
@@ -45003,14 +45020,14 @@ def: "The P69 cell line was derived by immortalization of human primary prostate
 synonym: "P69 cell" RELATED []
 synonym: "P69SV40T cell" RELATED []
 is_a: BTO:0002398 ! prostate epithelium cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-27T08:13:51Z
 
 [Term]
 id: BTO:0005983
 name: culture condition:cholesterol-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-28T09:59:07Z
 
 [Term]
@@ -45018,7 +45035,7 @@ id: BTO:0005984
 name: culture condition:carbon monoxide-grown cell
 synonym: "condition:CO-grown cell" RELATED []
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-28T09:59:55Z
 
 [Term]
@@ -45027,7 +45044,7 @@ name: plant ear
 def: "Fruiting spike of a cereal plant especially corn." [Vocabulary.com_Dictionary:https\://www.vocabulary.com/dictionary/]
 synonym: "corn ear" RELATED []
 is_a: BTO:0001278 ! spike
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-28T10:16:38Z
 
 [Term]
@@ -45040,7 +45057,7 @@ synonym: "HNSCC cell" RELATED []
 synonym: "squamous cell cancer of the head and neck" RELATED []
 synonym: "squamous cell carcinoma cell of the head and neck" RELATED []
 is_a: BTO:0005838 ! head and neck cancer cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-28T11:16:10Z
 
 [Term]
@@ -45050,7 +45067,7 @@ def: "Human hepatoma cell line." [PMID:12679910]
 synonym: "HLE cell" RELATED []
 synonym: "human hepatoma cell line" RELATED []
 is_a: BTO:0000578 ! hepatoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-28T11:39:49Z
 
 [Term]
@@ -45061,7 +45078,7 @@ synonym: "CHO Lec4 cell" RELATED []
 synonym: "Lec4 cell" RELATED []
 synonym: "ProLec4.7b cell" RELATED []
 relationship: develops_from BTO:0000246 ! CHO cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-28T11:50:47Z
 
 [Term]
@@ -45072,7 +45089,7 @@ synonym: "CHO Lec4A cell" RELATED []
 synonym: "Lec4A cell" RELATED []
 synonym: "ProLec4A.12.2 cell" RELATED []
 relationship: develops_from BTO:0000246 ! CHO cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-28T11:55:47Z
 
 [Term]
@@ -45084,7 +45101,7 @@ synonym: "archinephric duct" RELATED []
 synonym: "nephric duct" RELATED []
 synonym: "Wolffian duct" RELATED []
 relationship: develops_from BTO:0005991 ! pronephric duct
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-28T14:31:44Z
 
 [Term]
@@ -45092,7 +45109,7 @@ id: BTO:0005991
 name: pronephric duct
 def: "It is the predecessor of the Wolffian duct. The development of the pronephric duct is a part of the development of the urinary and reproductive organs." [Wikipedia:The_Free_Encyclopedia]
 relationship: part_of BTO:0000379 ! embryo
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-28T14:34:52Z
 
 [Term]
@@ -45100,7 +45117,7 @@ id: BTO:0005992
 name: pseudostem
 def: "A false stem made of the rolled bases of leaves, which may be 2 or 3 m tall as in banana." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0001300 ! stem
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-28T14:44:23Z
 
 [Term]
@@ -45109,7 +45126,7 @@ name: basal swimming muscle
 synonym: "basal muscle of the swimming paddle" RELATED []
 is_a: BTO:0000887 ! muscle
 relationship: part_of BTO:0001266 ! invertebrate muscular system
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-28T14:51:10Z
 
 [Term]
@@ -45117,7 +45134,7 @@ id: BTO:0005994
 name: RWPE-2 cell
 def: "Normal human epithelial prostate cell line. RWPE-2 cells were derived from RWPE-1 cells by transformation with Ki-ras using the Kirsten murine sarcoma virus, Ki-MuSV." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 relationship: develops_from BTO:0003709 ! RWPE-1 cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-29T08:25:19Z
 
 [Term]
@@ -45128,14 +45145,14 @@ synonym: "SCC-11B cell" RELATED []
 synonym: "SCC11B cell" RELATED []
 synonym: "UMSCC-11B cell" RELATED []
 is_a: BTO:0002709 ! head and neck squamous cell carcinoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-29T08:37:00Z
 
 [Term]
 id: BTO:0005996
 name: stromal cell line
 relationship: develops_from BTO:0002064 ! stromal cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-29T08:45:58Z
 
 [Term]
@@ -45144,7 +45161,7 @@ name: ST-2 cell
 def: "Murine, Mus musculus, stromal cell line; established from Whitlock-Witte type long-term bone marrow culture of BC8 mice." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 synonym: "ST2 cell" RELATED []
 is_a: BTO:0005996 ! stromal cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-29T08:46:16Z
 
 [Term]
@@ -45152,7 +45169,7 @@ id: BTO:0005998
 name: walking leg
 def: "At the thorax of a prawn there are five pairs of walking legs. They are used for crawling on the river bed. Of the five pairs of walking legs the first two pairs bear pincers at their free ends and are, therefore, called chelate legs; these along with the rostrum and the spines are regarded as organs of offence and defence." [Prawn:External_Features_and_LifeHistory\:http\://www.biologydiscussion.com/zoology/prawn/]
 is_a: BTO:0001503 ! thoracic leg
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-30T09:27:31Z
 
 [Term]
@@ -45160,7 +45177,7 @@ id: BTO:0005999
 name: chelate leg
 def: "At the thorax of a prawn there are five pairs of walking legs. They are used for crawling on the river bed. Of the five pairs of walking legs the first two pairs bear pincers at their free ends and are, therefore, called chelate legs; these along with the rostrum and the spines are regarded as organs of offence and defence." [Prawn:External_Features_and_LifeHistory\:http\://www.biologydiscussion.com/zoology/prawn/]
 is_a: BTO:0005998 ! walking leg
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-30T09:30:56Z
 
 [Term]
@@ -45168,7 +45185,7 @@ id: BTO:0006000
 name: WPE-int cell
 def: "WPE-int cells were derived from the RWPE-1 cell line after two consecutive cycles of single cell cloning. To establish the RWPE-1 cell line, epithelial cells from the peripheral zone of a histologically normal adult human prostate were transfected with a plasmid carrying one copy of the human papilloma virus 18 genome." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 relationship: develops_from BTO:0003709 ! RWPE-1 cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-30T09:36:08Z
 
 [Term]
@@ -45179,7 +45196,7 @@ synonym: "GBM stem cell line" RELATED []
 synonym: "glioblastoma multiforme stem cell line" RELATED []
 synonym: "glioblastome multiforme stem cell line" RELATED []
 is_a: BTO:0005949 ! glioblastoma multiforme cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-30T09:56:48Z
 
 [Term]
@@ -45189,7 +45206,7 @@ def: "Human glioblastoma multiforme stem cell line, GSC." [PMID:23307328]
 synonym: "0308-GSC cell" RELATED []
 synonym: "GSC-0308 cell" RELATED []
 is_a: BTO:0006001 ! GSC cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-30T09:59:36Z
 
 [Term]
@@ -45198,7 +45215,7 @@ name: 0822 cell
 def: "Human glioblastoma multiforme stem cell line, GSC." [PMID:23307328]
 synonym: "GSC-0822 cell" RELATED []
 is_a: BTO:0006001 ! GSC cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-30T10:02:38Z
 
 [Term]
@@ -45208,7 +45225,7 @@ def: "Human glioblastoma multiforme stem cell line, GSC." [PMID:23307328]
 synonym: "1228-GSC" RELATED []
 synonym: "GSC-1228 cell" RELATED []
 is_a: BTO:0006001 ! GSC cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-30T10:03:08Z
 
 [Term]
@@ -45216,7 +45233,7 @@ id: BTO:0006005
 name: brachial nerve
 def: "The brachial nerve of an octopus travels out to innervate the arms, that means more precisely to connect the nervous system of the head and the nervous system of the arms." [A_View_of_the_Octopus_Brain:http\://cephalove.blogspot.de/2010/06/view-of-octopus-brain.html]
 is_a: BTO:0000925 ! nerve
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-30T10:09:47Z
 
 [Term]
@@ -45224,7 +45241,7 @@ id: BTO:0006006
 name: pseudopalisading cell
 def: "Glioblastoma (GBM) is a highly malignant, rapidly progressive astrocytoma that is distinguished pathologically from lower grade tumors by necrosis and microvascular hyperplasia. Necrotic foci are typically surrounded by pseudopalisading cells, a configuration that is relatively unique to malignant gliomas and has long been recognized as an ominous prognostic feature." [PMID:16783163]
 is_a: BTO:0002373 ! glioblastoma multiforme cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-09-30T10:24:40Z
 
 [Term]
@@ -45235,7 +45252,7 @@ synonym: "LB-24 cell" RELATED []
 synonym: "LB24 cell" RELATED []
 synonym: "LB24-MEL cell" RELATED []
 is_a: BTO:0000849 ! melanoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-10-04T12:09:34Z
 
 [Term]
@@ -45243,7 +45260,7 @@ id: BTO:0006008
 name: choroid plexus epithelium
 def: "The choroid plexus epithelium has functions as a barrier at the interface between the blood and cerebrospinal fluid (CSF) highly differentiated." [Frontiers:http\://journal.frontiersin.org/researchtopic/2181/the-role-of-choroid-plexus-in-brain-disorders]
 relationship: part_of BTO:0000258 ! choroid plexus
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2016-10-04T15:36:21Z
 
 [Term]
@@ -45254,7 +45271,7 @@ synonym: "NPC SUNE1 cell" RELATED []
 synonym: "SUNE 1 cell" RELATED []
 synonym: "SUNE1 cell" RELATED []
 is_a: BTO:0003960 ! nasopharyngeal carcinoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-03-20T20:07:17Z
 
 [Term]
@@ -45265,7 +45282,7 @@ synonym: "NPC SUNE-1 5-8F cell" RELATED []
 synonym: "SUNE-1 5-8F cell" RELATED []
 synonym: "SUNE-1-5-8F cell" RELATED []
 relationship: develops_from BTO:0006009 ! SUNE-1 cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-03-20T20:12:54Z
 
 [Term]
@@ -45276,7 +45293,7 @@ synonym: "NPC SUNE-1 6-10B cell" RELATED []
 synonym: "SUNE-1 6-10B cell" RELATED []
 synonym: "SUNE-1-6-10B cell" RELATED []
 relationship: develops_from BTO:0006009 ! SUNE-1 cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-03-20T20:17:09Z
 
 [Term]
@@ -45286,7 +45303,7 @@ def: "Non-tumorigenic subline of SUNE-1 cell line." [PMID:12485491]
 synonym: "NPC SUNE-1 13-9B cell" RELATED []
 synonym: "SUNE-1 13-9B cell" RELATED []
 relationship: develops_from BTO:0006009 ! SUNE-1 cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-03-20T20:19:04Z
 
 [Term]
@@ -45295,7 +45312,7 @@ name: anterior horn cell
 def: "Motor neuron in the anterior horn." [Mosbys_Medical_Dictionary:9th_Edition_2009_Elsevier]
 is_a: BTO:0000312 ! motoneuron
 relationship: part_of BTO:0005151 ! anterior horn
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-03-27T19:29:36Z
 
 [Term]
@@ -45304,7 +45321,7 @@ name: axillary bud meristem
 def: "A shoot system meristem formed in an axil." [Plant_Ontology:\:Gramene]
 synonym: "axillary meristem" RELATED []
 is_a: BTO:0000852 ! meristem
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-03-27T19:46:26Z
 
 [Term]
@@ -45315,7 +45332,7 @@ synonym: "Bre-80 cell" RELATED []
 synonym: "BRE80 cell" RELATED []
 synonym: "Bre80 cell" RELATED []
 is_a: BTO:0000816 ! breast cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-03-27T20:08:39Z
 
 [Term]
@@ -45328,7 +45345,7 @@ synonym: "C4-1 cell" RELATED []
 synonym: "C41 cell" RELATED []
 synonym: "C4I cell" RELATED []
 is_a: BTO:0002212 ! cervical squamous cell carcinoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-03-27T20:30:31Z
 
 [Term]
@@ -45336,7 +45353,7 @@ id: BTO:0006017
 name: cormel
 def: "A small or secondary corm produced by a larger corm." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/corm]
 relationship: develops_from BTO:0000285 ! corm
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-03-28T10:22:57Z
 
 [Term]
@@ -45345,7 +45362,7 @@ name: CT26.WT cell
 def: "A clone of CT-26 cell line." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 synonym: "CT26WT cell" RELATED []
 relationship: develops_from BTO:0003630 ! CT-26 cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-03-28T10:32:12Z
 
 [Term]
@@ -45355,7 +45372,7 @@ def: "Lethal subclone of CT26.WT cell." [ATCC_American_Cell_Type_Culture_Collect
 synonym: "CT26 clone 25" RELATED []
 synonym: "CT26-clone 25 cell" RELATED []
 relationship: develops_from BTO:0006018 ! CT26.WT cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-03-28T10:38:41Z
 
 [Term]
@@ -45364,7 +45381,7 @@ name: female accessory gland
 def: "The reproductive system of female insects are made up of a pair of ovaries, accessory glands, one or more spermathecae, and ducts connecting these parts. The accessory glands produce the substances to help package and lay the eggs." [Wikipedia:The_Free_Encyclopedia]
 synonym: "accessory gland" RELATED []
 is_a: BTO:0000254 ! female reproductive gland
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-04-25T10:31:38Z
 
 [Term]
@@ -45374,7 +45391,7 @@ def: "Human non-small cell lung adenocarcinoma cell line; established from a ple
 synonym: "H-2110 cell" RELATED []
 synonym: "H2110 cell" RELATED []
 is_a: BTO:0004078 ! non-small cell lung adenocarcinoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-03-28T16:38:19Z
 
 [Term]
@@ -45384,7 +45401,7 @@ def: "Human lung non-small cell lung cancer cell line." [ATCC_American_Cell_Type
 synonym: "H-2172 cell" RELATED []
 synonym: "H2172 cell" RELATED []
 is_a: BTO:0002553 ! non-small cell lung cancer cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-03-28T16:47:02Z
 
 [Term]
@@ -45394,7 +45411,7 @@ def: "Human non-small cell lung adenocarcinoma cell line." [ATCC_American_Cell_T
 synonym: "H-2228 cell" RELATED []
 synonym: "H2228 cell" RELATED []
 is_a: BTO:0004078 ! non-small cell lung adenocarcinoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-03-28T16:56:00Z
 
 [Term]
@@ -45404,7 +45421,7 @@ def: "Human lung papillary adenocarcinoma cell line; established from a 53 years
 synonym: "H-820 cell" RELATED []
 synonym: "H820 cell" RELATED []
 is_a: BTO:0000762 ! lung cancer cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-03-28T17:10:17Z
 
 [Term]
@@ -45413,7 +45430,7 @@ name: HCC-2279 cell
 def: "Human lung adeno-squamous cell carcinoma cell line." [KCLB_Korean_Cell_Line_Bank:cellbank.snu.ac.kr/english/]
 synonym: "HCC2279 cell" RELATED []
 is_a: BTO:0000762 ! lung cancer cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-03-30T17:24:21Z
 
 [Term]
@@ -45423,7 +45440,7 @@ def: "Human cervical carcinoma cell line." [PMID:9596902]
 synonym: "HCC 94 cell" RELATED []
 synonym: "HCC94 cell" RELATED []
 is_a: BTO:0001967 ! cervical cancer cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-03-30T17:31:25Z
 
 [Term]
@@ -45433,7 +45450,7 @@ def: "Human lung squamous cell carcinoma cell line." [CreativeBioarray:www.creat
 synonym: "HCC 95 cell" RELATED []
 synonym: "HCC95 cell" RELATED []
 is_a: BTO:0002202 ! lung squamous cell carcinoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-03-30T17:34:09Z
 
 [Term]
@@ -45443,7 +45460,7 @@ def: "Human lung adenocarcinoma cell line." [CreativeBioarray:www.creative-bioar
 synonym: "HCC 1171 cell" RELATED []
 synonym: "HCC1171 cell" RELATED []
 is_a: BTO:0001911 ! lung adenocarcinoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-03-30T17:40:34Z
 
 [Term]
@@ -45454,7 +45471,7 @@ synonym: "Hep G2/ ADM cell" RELATED []
 synonym: "Hep G2/ADM cell" RELATED []
 synonym: "HepG2/ADM cell" RELATED []
 relationship: develops_from BTO:0000599 ! Hep-G2 cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-03-30T17:43:58Z
 
 [Term]
@@ -45464,7 +45481,7 @@ def: "Human oral squamous cell carcinoma cell line." [PMID:27779690]
 synonym: "HOC 313 cell" RELATED []
 synonym: "HOC313 cell" RELATED []
 is_a: BTO:0002211 ! oral squamous cell carcinoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-03-30T17:58:50Z
 
 [Term]
@@ -45472,7 +45489,7 @@ id: BTO:0006031
 name: HUASMC cell
 def: "Human umbilical artery smooth muscle cell line." [Cell_Applications:https\://www.cellapplications.com//]
 is_a: BTO:0001209 ! umbilical cord cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-03-30T18:02:17Z
 
 [Term]
@@ -45481,7 +45498,7 @@ name: JVM-3 cell
 def: "Human chronic B cell leukemia cell line; established from the peripheral blood of a 73-year-old man with B-prolymphocytic leukemia at diagnosis." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 synonym: "JVM3 cell" RELATED []
 is_a: BTO:0000741 ! lymphocytic leukemia cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-03-30T18:36:09Z
 
 [Term]
@@ -45489,7 +45506,7 @@ id: BTO:0006033
 name: Kenyon cell
 def: "The intrinsic neurons of the mushroom body. They are produced from precursors known as neuroblasts." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0002675 ! mushroom body
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-03-30T18:51:36Z
 
 [Term]
@@ -45497,7 +45514,7 @@ id: BTO:0006034
 name: KRIB cell
 def: "Human osteosarcoma cell line, Ki-ras transformed TE85 line." [PMID:16170668]
 relationship: develops_from BTO:0005416 ! MNNG/HOS cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-03-30T19:07:22Z
 
 [Term]
@@ -45508,14 +45525,14 @@ synonym: "foramen occipitale magnum" RELATED []
 synonym: "Grosses Hinterhauptloch" RELATED GE []
 synonym: "magnum" RELATED []
 relationship: part_of BTO:0001295 ! cranium
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-03-30T19:21:46Z
 
 [Term]
 id: BTO:0006036
 name: subcutaneous tissue cell line
 relationship: develops_from BTO:0004525 ! subcutaneous tissue
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-04-03T18:23:44Z
 
 [Term]
@@ -45527,7 +45544,7 @@ synonym: "L-Wnt3A cell" RELATED []
 synonym: "LWnt-3A cell" RELATED []
 synonym: "LWnt3A cell" RELATED []
 is_a: BTO:0006036 ! subcutaneous tissue cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-04-03T18:24:06Z
 
 [Term]
@@ -45536,7 +45553,7 @@ name: LK-87 cell
 def: "Human lung non-small cell adenocarcinoma cell line." [PMID:23062075]
 synonym: "LK87 cell" RELATED []
 is_a: BTO:0004078 ! non-small cell lung adenocarcinoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-04-03T18:33:15Z
 
 [Term]
@@ -45548,7 +45565,7 @@ synonym: "MDA-MB415 cell" RELATED []
 synonym: "MDA415 cell" RELATED []
 is_a: BTO:0001912 ! breast adenocarcinoma cell line
 is_a: BTO:0004086 ! mammary gland tumor cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-04-03T18:38:13Z
 
 [Term]
@@ -45556,7 +45573,7 @@ id: BTO:0006040
 name: mesophyll cell
 def: "Mesophyll cells are a type of ground tissue found in the plants leaves. There are two types: palisade mesophyll cells and spongey mesophyll cells." [School_of_Biomedical_Sciences:Wiki]
 is_a: BTO:0000858 ! mesophyll
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-04-03T18:44:16Z
 
 [Term]
@@ -45565,7 +45582,7 @@ name: MMT-060562 cell
 def: "Mouse mammary gland tumor cell line." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 synonym: "MMT 060562 cell" RELATED []
 is_a: BTO:0004086 ! mammary gland tumor cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-04-03T18:49:18Z
 
 [Term]
@@ -45578,7 +45595,7 @@ synonym: "NCI-H 1581 cell" RELATED []
 synonym: "NCI-H-1581 cell" RELATED []
 synonym: "NCIH1581 cell" RELATED []
 is_a: BTO:0002553 ! non-small cell lung cancer cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-04-04T08:43:56Z
 
 [Term]
@@ -45586,7 +45603,7 @@ id: BTO:0006043
 name: NB4-LR1 cell
 def: "Retinoid-maturation-resistant subclone of the acute promyelocytic leukemia cell line NB4." [PMID:18094716]
 relationship: develops_from BTO:0002136 ! NB-4 cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-04-04T08:49:56Z
 
 [Term]
@@ -45594,7 +45611,7 @@ id: BTO:0006044
 name: NB4-LR2 cell
 def: "All-trans retinoic acid-resistant subclone of the acute promyelocytic leukemia cell line NB4." [The_Role_of_Histone_Demethylases_and_DNA_Methyltransferases_in_the_Transcription_Regulation_of_HOX_Genes:https\://ash.confex.com/ash/2016/webprogram/Paper93548.html]
 relationship: develops_from BTO:0002136 ! NB-4 cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-04-04T09:05:51Z
 
 [Term]
@@ -45602,7 +45619,7 @@ id: BTO:0006045
 name: nasopharyngeal cell line
 is_a: BTO:0000819 ! pharyngeal cell line
 relationship: develops_from BTO:0000662 ! nasopharynx
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-04-04T09:36:23Z
 
 [Term]
@@ -45613,7 +45630,7 @@ synonym: "NP-69-SV40T cell" RELATED []
 synonym: "NP69 cell" RELATED []
 synonym: "NP69SV40T cell" RELATED []
 is_a: BTO:0006045 ! nasopharyngeal cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-04-04T09:37:09Z
 
 [Term]
@@ -45621,7 +45638,7 @@ id: BTO:0006047
 name: PH5CH cell
 def: "Human immortalized non-neoplastic cell line; established by  transfection with a simian virus 40 large T antigen expression vector." [PMID:9714233]
 is_a: BTO:0000224 ! liver cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-04-04T10:04:00Z
 
 [Term]
@@ -45630,7 +45647,7 @@ name: PH5CH-8 cell
 def: "Clone of PH5CH cell displaying more efficient hepatitis C virus replication." [PMID:9714233]
 synonym: "PH5CH8 cell" RELATED []
 relationship: develops_from BTO:0006047 ! PH5CH cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-04-04T10:06:16Z
 
 [Term]
@@ -45639,7 +45656,7 @@ name: PH5CH-1 cell
 def: "Clone of PH5CH cell displaying more efficient hepatitis C virus replication." [PMID:9714233]
 synonym: "PH5CH1 cell" RELATED []
 relationship: develops_from BTO:0006047 ! PH5CH cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-04-04T10:10:23Z
 
 [Term]
@@ -45648,7 +45665,7 @@ name: PH5CH-7 cell
 def: "Clone of PH5CH cell displaying more efficient hepatitis C virus replication." [PMID:9714233]
 synonym: "PH5CH7 cell" RELATED []
 relationship: develops_from BTO:0006047 ! PH5CH cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-04-04T10:10:45Z
 
 [Term]
@@ -45658,7 +45675,7 @@ def: "A cartilage bar in the mandibular arch that forms a temporary supporting s
 synonym: "mandibular cartilage" RELATED []
 synonym: "Meckel cartilage" RELATED []
 relationship: part_of BTO:0000379 ! embryo
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-04-04T10:20:02Z
 
 [Term]
@@ -45668,7 +45685,7 @@ def: "Human neuroblastoma cell line." [PMID:21625996]
 synonym: "SJ-NB-10 cell" RELATED []
 synonym: "SJNB10 cell" RELATED []
 is_a: BTO:0000932 ! neuroblastoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-04-04T10:38:08Z
 
 [Term]
@@ -45678,7 +45695,7 @@ def: "Human neuroblastoma cell line." [PMID:21625996]
 synonym: "SJ-NB-1 cell" RELATED []
 synonym: "SJNB1 cell" RELATED []
 is_a: BTO:0000932 ! neuroblastoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-04-04T10:41:15Z
 
 [Term]
@@ -45688,7 +45705,7 @@ def: "Human neuroblastoma cell line." [PMID:21625996]
 synonym: "SJ-NB-6 cell" RELATED []
 synonym: "SJNB6 cell" RELATED []
 is_a: BTO:0000932 ! neuroblastoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-04-04T10:41:36Z
 
 [Term]
@@ -45698,7 +45715,7 @@ def: "Human neuroblastoma cell line." [PMID:21625996]
 synonym: "SJ-NB-8 cell" RELATED []
 synonym: "SJNB8 cell" RELATED []
 is_a: BTO:0000932 ! neuroblastoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-04-04T10:42:02Z
 
 [Term]
@@ -45708,7 +45725,7 @@ def: "Human neuroblastoma cell line." [PMID:21625996]
 synonym: "SJ-NB-12 cell" RELATED []
 synonym: "SJNB12 cell" RELATED []
 is_a: BTO:0000932 ! neuroblastoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-04-04T10:42:20Z
 
 [Term]
@@ -45719,7 +45736,7 @@ comment: P means parental cell.
 synonym: "SKW3 cell" RELATED []
 synonym: "SKW3/P cell" RELATED []
 relationship: develops_from BTO:0002547 ! KE-37 cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-04-07T14:18:53Z
 
 [Term]
@@ -45730,7 +45747,7 @@ comment: Contaminated. Shown to be a HeLa derivative.
 synonym: "TCA8113 cell" RELATED []
 synonym: "Tca8113 cell" RELATED []
 relationship: develops_from BTO:0000567 ! HeLa cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-04-07T14:33:55Z
 
 [Term]
@@ -45741,7 +45758,7 @@ synonym: "ES-I3 cell" RELATED []
 synonym: "I3 cell" RELATED []
 synonym: "TE03 cell" RELATED []
 is_a: BTO:0001581 ! embryonic stem cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-04-07T14:39:06Z
 
 [Term]
@@ -45751,7 +45768,7 @@ def: "Human embryonic stem cell line from a male." [WiCell:www.wicell.org/]
 synonym: "H1 cell" RELATED []
 synonym: "WA01 cell" RELATED []
 is_a: BTO:0001581 ! embryonic stem cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-04-07T15:12:25Z
 
 [Term]
@@ -45761,7 +45778,7 @@ def: "Human embryonic stem cell line from a male; established from human blastoc
 synonym: "H7 cell" RELATED []
 synonym: "WA07 cell" RELATED []
 is_a: BTO:0001581 ! embryonic stem cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-04-07T15:13:54Z
 
 [Term]
@@ -45771,7 +45788,7 @@ def: "Human embryonic stem cell line from a male; established from human blastoc
 synonym: "H9 cell" RELATED []
 synonym: "WA09 cell" RELATED []
 is_a: BTO:0001581 ! embryonic stem cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-04-07T15:16:21Z
 
 [Term]
@@ -45779,7 +45796,7 @@ id: BTO:0006063
 name: YAC-1 cell
 def: "Mouse lymphoma cell line; induced with moloney murine leukemia virus." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 is_a: BTO:0000104 ! lymphoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-04-07T15:19:17Z
 
 [Term]
@@ -45791,7 +45808,7 @@ synonym: " X-organ sinus gland complex" RELATED []
 synonym: "X-organ-sinus gland complex" RELATED []
 synonym: "X-organ-sinus-gland-complex" RELATED []
 relationship: part_of BTO:0001604 ! eyestalk
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-04-07T15:23:31Z
 
 [Term]
@@ -45803,7 +45820,7 @@ synonym: "BT474 LR cell" RELATED []
 synonym: "BT474-LR cell" RELATED []
 synonym: "LR BT474 cell" RELATED []
 relationship: develops_from BTO:0001932 ! BT-474 cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-04-25T11:51:58Z
 
 [Term]
@@ -45814,7 +45831,7 @@ synonym: "CLU213 cell" BROAD []
 synonym: "R22 cell" RELATED []
 is_a: BTO:0000947 ! neuronal cell line
 is_a: BTO:0002871 ! embryonic brain cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-04-25T15:37:36Z
 
 [Term]
@@ -45824,14 +45841,14 @@ synonym: "culture condition:2-methyl-1-propene-grown cell" RELATED []
 synonym: "culture condition:2-methylprop-1-ene-grown cell" RELATED []
 synonym: "culture condition:isobutene-grown cell" RELATED []
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-05-01T11:22:50Z
 
 [Term]
 id: BTO:0006068
 name: culture condition:lactate-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-05-01T11:28:54Z
 
 [Term]
@@ -45840,7 +45857,7 @@ name: OR-6 cell
 def: "HuH-7 derived ribavirin-resistant cell line." [PMID:23532970]
 synonym: "OR6 cell" RELATED []
 relationship: develops_from BTO:0001950 ! HuH-7 cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-05-02T14:19:57Z
 
 [Term]
@@ -45849,7 +45866,7 @@ name: Li-23 cell
 def: "A human hepatoma cell line." [PMID:19720094]
 synonym: "Li23 cell" RELATED []
 is_a: BTO:0000578 ! hepatoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-05-02T14:26:17Z
 
 [Term]
@@ -45858,7 +45875,7 @@ name: ORL-8 cell
 def: "Li23 derived ribavirin-sensitive cell line." [PMID:23532970]
 synonym: "ORL8 cell" RELATED []
 relationship: develops_from BTO:0006070 ! Li-23 cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-05-02T14:27:52Z
 
 [Term]
@@ -45868,14 +45885,14 @@ def: "Tongue epithelial cell line." [PMID:25872568]
 synonym: "TEC" RELATED []
 is_a: BTO:0000885 ! tongue cell line
 relationship: develops_from BTO:0000992 ! tongue epithelium
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-05-02T16:02:43Z
 
 [Term]
 id: BTO:0006073
 name: tongue epithelial cell
 relationship: part_of BTO:0000992 ! tongue epithelium
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-05-02T16:08:25Z
 
 [Term]
@@ -45884,7 +45901,7 @@ name: CNE-1 cell
 def: "Is thought to be a human nasopharyngeal carcinoma cell line. Seems to be the same as CNE-2. Could be generated by fusion of HeLa with an NPC cell line." [PMID:18196576]
 synonym: "CNE1 cell" RELATED []
 is_a: BTO:0003960 ! nasopharyngeal carcinoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-05-14T18:59:14Z
 
 [Term]
@@ -45893,7 +45910,7 @@ name: mHypoE-N43/5 cell
 def: "Embryonic mouse hypothalamus cell line." [Biocompare:http\://www.biocompare.com/]
 synonym: "N43/5 cell" RELATED []
 is_a: BTO:0000947 ! neuronal cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-05-14T19:15:43Z
 
 [Term]
@@ -45902,7 +45919,7 @@ name: benign prostatic hyperplasia cell
 def: "Benign enlargement of the prostate, a noncancerous increase in size of the prostate. BPH involves hyperplasia of prostatic stromal and epithelial cells, resulting in the formation of large, fairly discrete nodules in the transition zone of the prostate. It involves hyperplasia - an increase in the number of cells - rather than hypertrophy - a growth in the size of individual cells." [Wikipedia:The_Free_Encyclopedia]
 synonym: "BPH cell" RELATED []
 relationship: develops_from BTO:0001129 ! prostate gland
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-05-14T19:21:04Z
 
 [Term]
@@ -45911,7 +45928,7 @@ name: SAEC cell
 def: "Primary human small airway epithelial cells, isolated from normal human lung tissue at the distal portion of lung in the 1mm bronchiole area." [Lonza:www.lonza.com/]
 synonym: "primary human small airway epithelial cells" RELATED []
 relationship: develops_from BTO:0001866 ! bronchiolar epithelium
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-05-14T19:34:02Z
 
 [Term]
@@ -45919,7 +45936,7 @@ id: BTO:0006078
 name: pluripotent stem cell
 synonym: "PSC cell" RELATED []
 relationship: part_of BTO:0001489 ! whole body
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-05-14T19:55:53Z
 
 [Term]
@@ -45928,7 +45945,7 @@ name: hPSC cell
 def: "Human pluripotent stem cell. Includes human embryonic stem cells and human induced pluripotent stem cells. It can self-renew indefinitely in culture while maintaining the ability to become almost any cell type in the human body." [PMID:23362344]
 synonym: "human pluripotent stem cell" RELATED []
 is_a: BTO:0006078 ! pluripotent stem cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-05-14T19:58:25Z
 
 [Term]
@@ -45937,7 +45954,7 @@ name: hESC cell
 def: "Human embryonic stem cell." [PMID:23362344]
 synonym: "human embryonic stem cell" RELATED []
 is_a: BTO:0006079 ! hPSC cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-05-14T20:01:48Z
 
 [Term]
@@ -45946,7 +45963,7 @@ name: hiPSC cell
 def: "Human induced pluripotent stem cell." [PMID:23362344]
 synonym: "human induced pluripotent stem cell" RELATED []
 is_a: BTO:0006079 ! hPSC cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-05-14T20:03:32Z
 
 [Term]
@@ -45956,7 +45973,7 @@ def: "Oral squamous cell carcinoma cell line." [PMID:25901533]
 comment: Contaminated. Shown to be a HeLa derivative.
 synonym: "TSCCa cell" RELATED []
 relationship: develops_from BTO:0000567 ! HeLa cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-05-14T20:15:16Z
 
 [Term]
@@ -45967,7 +45984,7 @@ synonym: "U-87 MG/CDDP cell" RELATED []
 synonym: "U-87 MG/DDP cell" RELATED []
 synonym: "U87MG/DDP cell" RELATED []
 relationship: develops_from BTO:0002036 ! U-87MG cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-05-14T20:18:35Z
 
 [Term]
@@ -45977,7 +45994,7 @@ def: "Trophoblast cell having one nucleus." [Dictionary:http\://www.thefreedicti
 synonym: "einkernige Trophoblastzelle" RELATED GE []
 synonym: "uninucleated trophoblast cell" RELATED []
 is_a: BTO:0001079 ! trophoblast
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-05-14T20:26:02Z
 
 [Term]
@@ -45987,7 +46004,7 @@ def: "Head and neck cancer cell line." [PMID:24085294]
 comment: Problematic cell line. Contaminated. T404, T406, Tu 138, Tu 158LN, Tu 159, Tu 182, Tu 212 and Tu 212LN have been shown to be identical (PubMed 21868764). See http://web.expasy.org/cellosaurus/.
 synonym: "HNSCC 212LN cell" RELATED []
 is_a: BTO:0002709 ! head and neck squamous cell carcinoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-19T20:40:31Z
 
 [Term]
@@ -45998,7 +46015,7 @@ synonym: "HS-SY-II cell" RELATED []
 synonym: "HSSY-II cell" RELATED []
 synonym: "HSSYII cell" RELATED []
 is_a: BTO:0003436 ! synovial cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-19T20:52:12Z
 
 [Term]
@@ -46007,7 +46024,7 @@ name: caudolateral nidopallium
 def: "The avian Nidopallium caudolaterale is a multimodal area in the caudal telencephalon that is apparently not homologous to the mammalian prefrontal cortex but serves comparable functions." [BrainMaps.org:brainmaps.org]
 synonym: "nidopallium caudolaterale" RELATED []
 relationship: part_of BTO:0003389 ! nidopallium
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-21T17:38:04Z
 
 [Term]
@@ -46016,7 +46033,7 @@ name: KEL-FIB cell
 def: "Human skin connective tissue normal fibroblast cell line; established from a 35 years old black female." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 synonym: "KEL FIB cell" RELATED []
 is_a: BTO:0001619 ! skin fibroblast cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-21T17:43:07Z
 
 [Term]
@@ -46026,7 +46043,7 @@ def: "Human skin normal fibroblast cell line; established from a 39 years old bl
 synonym: "CCD 1113Sk cell" RELATED []
 synonym: "CCD1113Sk cell" RELATED []
 is_a: BTO:0001619 ! skin fibroblast cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-21T17:46:40Z
 
 [Term]
@@ -46036,7 +46053,7 @@ def: "Human epithelial breast mammary gland carcinoma cell line; established fro
 synonym: "HCC 1569 cell" RELATED []
 synonym: "HCC1569 cell" RELATED []
 is_a: BTO:0004086 ! mammary gland tumor cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-21T18:19:18Z
 
 [Term]
@@ -46046,7 +46063,7 @@ def: "The HeLa derivative HL3T1 is a sensitive indicator cell line for the HIV-1
 synonym: "HeLa HL3T1 cell" RELATED []
 synonym: "HL3T1 cell" RELATED []
 relationship: develops_from BTO:0000567 ! HeLa cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-21T18:23:39Z
 
 [Term]
@@ -46054,21 +46071,21 @@ id: BTO:0006092
 name: hTERT-HPNE cell
 def: "Human normal pancreas duct cell line; established from a 52 years old male." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 is_a: BTO:0000183 ! pancreatic cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-21T18:48:44Z
 
 [Term]
 id: BTO:0006093
 name: male inflorescence
 is_a: BTO:0000628 ! inflorescence
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-21T18:54:45Z
 
 [Term]
 id: BTO:0006094
 name: female inflorescence
 is_a: BTO:0000628 ! inflorescence
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-21T18:55:10Z
 
 [Term]
@@ -46076,14 +46093,14 @@ id: BTO:0006095
 name: LNCaP clone FGC
 def: "Human prostate cancer cell line; established from a 50 years old caucasian male; derived from metastatic site: left supraclavicular lymph node." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 relationship: develops_from BTO:0001321 ! LNCaP cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-22T18:41:17Z
 
 [Term]
 id: BTO:0006096
 name: culture condition:benzene-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-22T18:44:06Z
 
 [Term]
@@ -46091,7 +46108,7 @@ id: BTO:0006097
 name: HEKa cell
 def: "Normal human primary epidermal keratinocytes." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 is_a: BTO:0001413 ! primary cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-22T18:51:43Z
 
 [Term]
@@ -46101,7 +46118,7 @@ def: "The collection of cells at the root tip that generate all the tissues of a
 synonym: "root meristem" RELATED []
 is_a: BTO:0000034 ! apical meristem
 relationship: part_of BTO:0001243 ! shoot
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-24T16:31:58Z
 
 [Term]
@@ -46110,7 +46127,7 @@ name: S2-028 cell
 def: "Human pancreatic ductal adenocarcinoma cell line." [PMID:28289921]
 synonym: "SUIT2-028 cell" RELATED []
 relationship: develops_from BTO:0003493 ! SUIT-2 cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-24T16:35:28Z
 
 [Term]
@@ -46118,7 +46135,7 @@ id: BTO:0006100
 name: plant protocorm
 def: "A tuber structure that develops from the embryos of lycopods (Lycopodiaceae) and orchids (Orchidaceae)." [Encyclopedia.com:http\://www.encyclopedia.com]
 relationship: develops_from BTO:0001233 ! plant embryo
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-24T16:56:20Z
 
 [Term]
@@ -46126,7 +46143,7 @@ id: BTO:0006101
 name: insect protocorm
 def: "The part of an insect embryo posterior to the protocephalon." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/protocorm]
 relationship: part_of BTO:0000379 ! embryo
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-24T17:01:30Z
 
 [Term]
@@ -46134,7 +46151,7 @@ id: BTO:0006102
 name: activated skeletal muscle satellite cell
 def: "A skeletal muscle cell that has become mitotically active - typically following muscle damage." [CellOntology:https\://raw.githubusercontent.com/obophenotype/cell-ontology/master/cl.obo]
 is_a: BTO:0005787 ! skeletal muscle satellite cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-25T10:55:32Z
 
 [Term]
@@ -46142,14 +46159,14 @@ id: BTO:0006103
 name: quiescent skeletal muscle satellite cell
 def: "A skeletal muscle satellite cell that is mitotically quiescent. These cells are wedge shaped and have a large nuclear to cytoplasmic ratio with few organelles, a small nucleus and condensed interphase chromatin. Satellite cells typically remain in this state until activated following muscle damage." [CellOntology:https\://raw.githubusercontent.com/obophenotype/cell-ontology/master/cl.obo]
 is_a: BTO:0005787 ! skeletal muscle satellite cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-25T10:55:51Z
 
 [Term]
 id: BTO:0006104
 name: proliferating skeletal muscle satellite cell
 is_a: BTO:0005787 ! skeletal muscle satellite cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-25T10:59:24Z
 
 [Term]
@@ -46157,7 +46174,7 @@ id: BTO:0006105
 name: skeletal muscle satellite stem cell
 def: "A skeletal muscle satellite cell that divides by stem cell division.  A proportion of this population undergoes symmetric stem cell division, producing two skeletal muscle satellite stem cells. The rest undergo asymmetric stem cell division - retaining their identity while budding off a daughter cell that differentiates into an adult skeletal muscle myoblast." [CellOntology:https\://raw.githubusercontent.com/obophenotype/cell-ontology/master/cl.obo]
 is_a: BTO:0005787 ! skeletal muscle satellite cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-25T11:07:33Z
 
 [Term]
@@ -46168,21 +46185,21 @@ synonym: "adrenal cortical adenoma cell" RELATED []
 synonym: "adrenocortical adenoma cell" RELATED []
 is_a: BTO:0000178 ! adenoma cell
 is_a: BTO:0000592 ! adrenal gland cancer cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-25T11:15:14Z
 
 [Term]
 id: BTO:0006107
 name: endometrial luminal epithelium
 relationship: part_of BTO:0006109 ! uterine endometrial epithelium
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-25T19:36:42Z
 
 [Term]
 id: BTO:0006108
 name: endometrial glandular epithelium
 relationship: part_of BTO:0006109 ! uterine endometrial epithelium
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-25T19:38:35Z
 
 [Term]
@@ -46190,7 +46207,7 @@ id: BTO:0006109
 name: uterine endometrial epithelium
 synonym: "endometrial epithelium" RELATED []
 relationship: part_of BTO:0001422 ! uterine endometrium
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-25T19:52:49Z
 
 [Term]
@@ -46200,7 +46217,7 @@ def: "Macrophages that encourage inflammation. M1 \"killer\" macrophages are act
 synonym: "classically activated macrophage" RELATED []
 synonym: "inflammatory macrophage" RELATED []
 is_a: BTO:0000801 ! macrophage
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-26T10:34:57Z
 
 [Term]
@@ -46209,7 +46226,7 @@ name: M2 macrophage
 def: "Macrophages that decrease inflammation and encourage tissue repair. M2 is the phenotype of resident tissue macrophages, and can be further elevated by IL-4. M2 macrophages produce high levels of IL-10, TGF-beta and low levels of IL-12. Tumor-associated macrophages are mainly of the M2 phenotype, and seem to actively promote tumor growth." [Wikipedia:The_Free_Encyclopedia]
 synonym: "alternatively activated macrophage" RELATED []
 is_a: BTO:0000801 ! macrophage
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-26T10:37:24Z
 
 [Term]
@@ -46219,7 +46236,7 @@ def: "FAPs are tissue-resident mesenchymal stromal cells (MSCs). Current literat
 synonym: "FAP cell" RELATED []
 synonym: "fibro/adipogenic progenitor cell" RELATED []
 is_a: BTO:0003298 ! mesenchymal stem cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-26T11:02:44Z
 
 [Term]
@@ -46227,7 +46244,7 @@ id: BTO:0006113
 name: megaspore
 def: "A spore in heterosporous plants giving rise to female gametophytes and usually larger than a microspore." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/megaspore]
 is_a: BTO:0001171 ! spore
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-26T11:28:12Z
 
 [Term]
@@ -46237,7 +46254,7 @@ def: "The C19 MEL cell line is a thymidine kinase negative subclone of the 745 m
 synonym: "C19 MEL cell" RELATED []
 synonym: "C19-MEL cell" RELATED []
 relationship: develops_from BTO:0002885 ! MEL-745A cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-26T18:07:41Z
 
 [Term]
@@ -46245,7 +46262,7 @@ id: BTO:0006115
 name: mesenterial filament
 def: "A thickened rim or ribbon-like extension running along the free border of a mesentery from the end of the actinopharynx downwards. They aid in the capture and digestion of food materials and may also assist in inhibiting substrate competitors." [Coral_Reef_Information_System_Glossary:https\://definedterm.com/mesenterial_filament]
 is_a: BTO:0001262 ! soft body part
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-26T18:36:41Z
 
 [Term]
@@ -46253,7 +46270,7 @@ id: BTO:0006116
 name: microsclerotium
 def: "A very small sclerotium." [Wiktionary:https\://en.wiktionary.org/wiki/]
 is_a: BTO:0001810 ! sclerotium
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-26T18:54:06Z
 
 [Term]
@@ -46261,7 +46278,7 @@ id: BTO:0006117
 name: middle silk gland
 def: "The silk gland contains three compartments according its morphology and function, including the anterior silk gland, middle silk gland, and posterior silk gland. The fibroins and sericins are synthesized in the posterior and middle silk gland, respectively and then stored in the lumen of the silk gland as a concentrated aqueous silk solution." [PMID:27102218]
 is_a: BTO:0001250 ! silk gland
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-26T18:56:51Z
 
 [Term]
@@ -46272,7 +46289,7 @@ synonym: "MYCN-2 cell" RELATED []
 synonym: "MYCN-2 Tet-on cell" RELATED []
 synonym: "MYCN2 cell" RELATED []
 relationship: develops_from BTO:0005397 ! SH-EP cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-28T09:27:07Z
 
 [Term]
@@ -46281,7 +46298,7 @@ name: villous cytotrophoblast
 def: "An undifferentiated cytotrophoblastic stem cell will differentiate into a villous cytotrophoblast, which is what constitutes primary chorionic villi, and will eventually coalesce into villous syncytiotrophoblast." [Wikipedia:The_Free_Encyclopedia]
 synonym: "villus cytotrophoblast" RELATED []
 is_a: BTO:0000322 ! cytotrophoblast
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-28T10:33:38Z
 
 [Term]
@@ -46289,7 +46306,7 @@ id: BTO:0006120
 name: villous syncytiotrophoblast
 synonym: "villus syncytiotrophoblast" RELATED []
 is_a: BTO:0001335 ! syncytiotrophoblast
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-28T10:35:04Z
 
 [Term]
@@ -46297,7 +46314,7 @@ id: BTO:0006121
 name: synergid cell
 def: "Synergid cells are two specialized cells that lie adjacent to the egg cell in the female gametophyte of angiosperms and play an essential role in pollen tube guidance and function. The term synergid comes from the Greek synergos, which means working together and was reportedly coined by Eduard Strasburger, a famous 19th century botanist who was one of the first to note that these cells somehow assist fertilization of the egg." [Elucidating_the_Function_of_Synergid_Cells:https\://www.ncbi.nlm.nih.gov/pubmed/?term=27046830]
 relationship: part_of BTO:0000842 ! megagametophyte
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-28T11:03:21Z
 
 [Term]
@@ -46305,7 +46322,7 @@ id: BTO:0006122
 name: TU-KATO-III cell
 def: "Tumorigenic TU-kato-III cells were derived from the gastric cancer cell line KATO-III." [PMID:17505008]
 relationship: develops_from BTO:0001092 ! KATO-III cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-28T11:17:35Z
 
 [Term]
@@ -46315,7 +46332,7 @@ def: "T98 and T98G are two related cell lines that were derived from a human gli
 synonym: "T 98 cell" RELATED []
 synonym: "T98 cell" RELATED []
 is_a: BTO:0005949 ! glioblastoma multiforme cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-29T20:00:45Z
 
 [Term]
@@ -46323,7 +46340,7 @@ id: BTO:0006124
 name: C3ABR cell
 def: "Human lymphoblastoid cell line; established by Epstein-Barr virus transformation from an healthy individual." [PMID:11080496]
 is_a: BTO:0000773 ! lymphoblastoid cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-29T20:57:25Z
 
 [Term]
@@ -46331,7 +46348,7 @@ id: BTO:0006125
 name: AT1ABR cell
 def: "Human lymphoblastoid cell line; established from A-T (Ataxia telangiectasia) patients by Epstein-Barr virus immortalization." [PMID:21149446]
 is_a: BTO:0000773 ! lymphoblastoid cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-29T21:01:23Z
 
 [Term]
@@ -46339,15 +46356,15 @@ id: BTO:0006126
 name: AT25ABR cell
 def: "Human lymphoblastoid cell line; established from A-T (Ataxia telangiectasia) patients by Epstein-Barr virus immortalization." [PMID:21149446]
 is_a: BTO:0000773 ! lymphoblastoid cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2017-09-29T21:02:01Z
 
 [Term]
 id: BTO:0006127
 name: adventitious root primordium
-def: "Primordium of an adventitious root." [curators:mgr]
+def: "Primordium of an adventitious root." []
 is_a: BTO:0004791 ! root primordium
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-03-13T13:21:21Z
 
 [Term]
@@ -46357,7 +46374,7 @@ def: "The spinothalamic tract is a sensory pathway from the skin to the thalamus
 synonym: "anterolateral system" RELATED []
 synonym: "ventrolateral system" RELATED []
 relationship: part_of BTO:0001365 ! thalamus
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-03-13T13:32:00Z
 
 [Term]
@@ -46365,7 +46382,7 @@ id: BTO:0006129
 name: lateral spinothalamic tract
 def: "One of the two main parts of the spinathalamic tract. It transmits pain and temperature." [Wikipedia:The_Free_Encyclopedia]
 relationship: part_of BTO:0006128 ! spinothalamic tract
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-03-13T13:34:26Z
 
 [Term]
@@ -46374,14 +46391,14 @@ name: anterior spinothalamic tract
 def: "One of the two main parts of the spinathalamic tract. It transmits crude touch and firm pressure." [Wikipedia:The_Free_Encyclopedia]
 synonym: "ventral spinothalamic tract" RELATED []
 relationship: part_of BTO:0006128 ! spinothalamic tract
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-03-13T13:35:55Z
 
 [Term]
 id: BTO:0006131
 name: culture condition:B220+ cell
 is_a: BTO:0002008 ! culture condition:antigen-presenting cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-03-13T13:40:05Z
 
 [Term]
@@ -46389,7 +46406,7 @@ id: BTO:0006132
 name: corticospinal tract
 def: "The corticospinal tract is a descending tract of the spinal cord which contains bundles of axons which originate in the cerebral cortex and descend to synapse within the brainstem or spinal cord." [Physiopedia:https\://www.physio-pedia.com/]
 relationship: part_of BTO:0001279 ! spinal cord
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-03-13T13:45:30Z
 
 [Term]
@@ -46397,7 +46414,7 @@ id: BTO:0006133
 name: forespore
 def: "A precursor of a spore; specifically: a form preceding the endospore in some bacteria and characterized by diffuse response to chromatin stains." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/forespore]
 is_a: BTO:0001171 ! spore
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-03-13T13:55:18Z
 
 [Term]
@@ -46407,7 +46424,7 @@ def: "GR1+ is a granulocytic marker." [Wikipedia:The_Free_Encyclopedia]
 synonym: "culture condition:GR-1+ cell" RELATED []
 synonym: "culture condition:GR1 positive cell" RELATED []
 is_a: BTO:0002008 ! culture condition:antigen-presenting cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-03-14T09:10:26Z
 
 [Term]
@@ -46416,7 +46433,7 @@ name: HNE-1 cell
 def: "Human nasopharyngeal carcinoma cell line." [PMID:2364868]
 synonym: "HNE1 cell" RELATED []
 is_a: BTO:0003960 ! nasopharyngeal carcinoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-03-14T10:08:28Z
 
 [Term]
@@ -46425,7 +46442,7 @@ name: HONE-1 cell
 def: "Human nasopharyngeal carcinoma cell line." [PMID:28383207]
 synonym: "HONE1 cell" RELATED []
 is_a: BTO:0003960 ! nasopharyngeal carcinoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-03-14T10:27:19Z
 
 [Term]
@@ -46435,7 +46452,7 @@ def: "Human foreskin fibroblast cell line, established from a black newborn male
 synonym: "Hs 27 cell" RELATED []
 synonym: "Hs27 cell" RELATED []
 is_a: BTO:0002245 ! foreskin fibroblast cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-03-14T10:29:46Z
 
 [Term]
@@ -46444,7 +46461,7 @@ name: internal capsule
 def: "The internal capsule is a white matter structure situated in the inferomedial part of each cerebral hemisphere of the brain." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0000236 ! cerebral white matter
 relationship: part_of BTO:0000231 ! cerebral hemisphere
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-03-14T16:29:54Z
 
 [Term]
@@ -46454,7 +46471,7 @@ def: "Human nasopharyngeal carcinoma cell line." [PMID:25744845]
 synonym: "TW-03 cell" RELATED []
 synonym: "TW03 cell" RELATED []
 is_a: BTO:0003960 ! nasopharyngeal carcinoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-03-14T16:54:27Z
 
 [Term]
@@ -46462,7 +46479,7 @@ id: BTO:0006140
 name: SN4741 cell
 def: "Cell line from substantia nigra dopaminergic cells derived from transgenic mouse embryos." [PMID:28334019]
 is_a: BTO:0004199 ! substantia nigra cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-03-14T16:59:34Z
 
 [Term]
@@ -46474,7 +46491,7 @@ synonym: "LU-99 cell" RELATED []
 synonym: "Lu99 cell" RELATED []
 synonym: "LU99 cell" RELATED []
 is_a: BTO:0002411 ! giant cell carcinoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-03-17T10:46:47Z
 
 [Term]
@@ -46483,7 +46500,7 @@ name: M4A4 LM3-4 CL16 GFP cell
 def: "Human melanocyte melanoma cell line. Recent studies have generated questions about the origin of the parent cell line, MDA-MB-435. Gene expression analysis of the cells produced microarrays in which MDA-MB-435 clustered with cell lines of melanoma origin instead of breast." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 synonym: "M-4A4 cell" RELATED []
 is_a: BTO:0000849 ! melanoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-03-17T10:55:04Z
 
 [Term]
@@ -46493,7 +46510,7 @@ def: "Human hepatocellular carcinoma cell line." [PMID:21666704]
 comment: Seems to be a synonym of BTO:0004469, LM-3 cell.
 synonym: "MHCCLM-3 cell" RELATED []
 is_obsolete: true
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-03-17T11:14:57Z
 
 [Term]
@@ -46502,7 +46519,7 @@ name: NM2C5 cell
 def: "Human melanocyte melanoma cell line. Recent studies have generated questions about the origin of the parent cell line, MDA-MB-435. Additional studies have since corroborated a melanocyte origin of MDA-MB-435, to which ATCC has responded by pursuing its own investigation into the identity of this cell line." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 synonym: "NM-2C5 cell" RELATED []
 is_a: BTO:0000849 ! melanoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-03-17T13:51:14Z
 
 [Term]
@@ -46512,7 +46529,7 @@ def: "Human melanocyte melanoma cell line. Recent studies have generated questio
 synonym: "NM-2C5-GFP cell" RELATED []
 synonym: "NM2C5 GFP cell" RELATED []
 is_a: BTO:0000849 ! melanoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-03-17T13:54:32Z
 
 [Term]
@@ -46520,7 +46537,7 @@ id: BTO:0006146
 name: culture condition:corn steep liquor-grown cell
 def: "Corn steep liquor is a by-product of corn wet-milling.  A viscous concentrate of corn solubles which contains amino acids, vitamins and minerals, it is an important constituent of some growth media." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-04-13T09:45:55Z
 
 [Term]
@@ -46528,7 +46545,7 @@ id: BTO:0006147
 name: IHH cell
 def: "Immortalized human hepatocyte cell line." [PMID:28013369]
 is_a: BTO:0000224 ! liver cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-04-13T10:35:20Z
 
 [Term]
@@ -46537,7 +46554,7 @@ name: mesenchymal glioma stem cell
 synonym: "mesenchymal GSC cell" RELATED []
 is_a: BTO:0003298 ! mesenchymal stem cell
 is_a: BTO:0006155 ! glioma stem cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-04-13T10:39:33Z
 
 [Term]
@@ -46548,7 +46565,7 @@ synonym: "Flp-In 293 T-Rex cell" RELATED []
 synonym: "Flp-In-T-REx cell" RELATED []
 synonym: "HEK293 Flp-In T-REx cell" RELATED []
 relationship: develops_from BTO:0005238 ! T-REx 293 cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-04-16T11:11:01Z
 
 [Term]
@@ -46556,7 +46573,7 @@ id: BTO:0006150
 name: plasmablastic lymphoma cell
 def: "Plasmablastic lymphoma is a type of large B-cell lymphoma." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0001690 ! B-cell lymphoma cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-04-16T11:21:21Z
 
 [Term]
@@ -46564,7 +46581,7 @@ id: BTO:0006151
 name: coral nubbin
 def: "Large coral colonies are fragmented into nubbins and attached to a substrate using Gorilla Glue. They are cultivated in open flow seawater tanks." [PMID:27114888]
 is_a: BTO:0001384 ! culture condition:tissue culture
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-04-16T11:26:31Z
 
 [Term]
@@ -46572,7 +46589,7 @@ id: BTO:0006152
 name: microtome section
 def: "A microtome is a tool used to cut extremely thin slices of material, known as sections." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0001490 ! other source
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-04-16T11:28:31Z
 
 [Term]
@@ -46581,7 +46598,7 @@ name: nigrostriatal system
 def: "System relating to, or joining the corpus striatum and the substantia nigra. Referring to the efferent connection." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/nigrostriatal]
 synonym: "striatonigral system" RELATED []
 relationship: part_of BTO:0001484 ! nervous system
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-04-16T11:45:30Z
 
 [Term]
@@ -46590,7 +46607,7 @@ name: renal proximal tubule epithelial cell
 synonym: "proximal tubule epithelial cell" RELATED []
 synonym: "RPTEC cell" RELATED []
 relationship: part_of BTO:0003576 ! renal proximal tubule epithelium
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-04-16T13:15:18Z
 
 [Term]
@@ -46598,7 +46615,7 @@ id: BTO:0006155
 name: glioma stem cell
 synonym: "GSC cell" RELATED []
 is_a: BTO:0002881 ! neural stem cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-04-16T13:24:28Z
 
 [Term]
@@ -46606,7 +46623,7 @@ id: BTO:0006156
 name: proneural glioma stem cell
 synonym: "PN-GSC cell" RELATED []
 is_a: BTO:0006155 ! glioma stem cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-04-16T13:25:16Z
 
 [Term]
@@ -46618,7 +46635,7 @@ synonym: "olivo-cerebellar tract" RELATED []
 synonym: "olivocerebellar tract" RELATED []
 synonym: "tractus olivocerebellaris" RELATED []
 relationship: part_of BTO:0001484 ! nervous system
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-04-16T13:29:07Z
 
 [Term]
@@ -46626,7 +46643,7 @@ id: BTO:0006158
 name: root vascular cylinder
 def: "In the roots, the vascular tissue is organized within a single central vascular cylinder." [Encyclopedia_Britannica:http\://www.britannica.com/]
 relationship: part_of BTO:0001188 ! root
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-04-16T19:39:46Z
 
 [Term]
@@ -46634,7 +46651,7 @@ id: BTO:0006159
 name: rubrospinal tract
 def: "Spinal cord motor tract emanating from the red nucleus." [Saunders_Comprehensive_Veterinary_Dictionary:3rd_Edition_2007_Elsevier]
 relationship: part_of BTO:0001279 ! spinal cord
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-04-19T11:11:06Z
 
 [Term]
@@ -46646,7 +46663,7 @@ synonym: "olivoponto cerebellar fiber" RELATED []
 synonym: "ponto-/olivo-cerebellar fiber" RELATED []
 synonym: "ponto-olivo-cerebellar fiber" RELATED []
 relationship: part_of BTO:0006157 ! olivocerebellar fiber system
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-04-19T11:18:23Z
 
 [Term]
@@ -46655,7 +46672,7 @@ name: pontocerebellar fiber
 def: "The pontocerebellar fibers are the second order neuron fibers of the corticopontocerebellar tracts that cross to the other side of the pons and run within the middle cerebellar peduncles, from the pons to the contralateral cerebellum." [Wikipedia:The_Free_Encyclopedia]
 synonym: "ponto-cerebellar fiber" RELATED []
 relationship: part_of BTO:0006157 ! olivocerebellar fiber system
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-04-19T11:25:27Z
 
 [Term]
@@ -46664,7 +46681,7 @@ name: reproductive gland
 synonym: "gonad" RELATED []
 synonym: "sexual gland" RELATED []
 is_a: BTO:0000081 ! reproductive system
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-04-19T14:09:29Z
 
 [Term]
@@ -46673,7 +46690,7 @@ name: C-2 cell
 def: "Histaminergic neuron of Aplysia californica." [PMID:6179570]
 synonym: "C2 cell" RELATED []
 is_a: BTO:0005819 ! histaminergic neuron
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-08-21T08:42:28Z
 
 [Term]
@@ -46681,7 +46698,7 @@ id: BTO:0006164
 name: cancer-infiltrating inflammatory cell
 synonym: "CIIC cell" RELATED []
 is_a: BTO:0003861 ! inflammatory cell
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-08-21T08:51:16Z
 
 [Term]
@@ -46689,7 +46706,7 @@ id: BTO:0006165
 name: endometrial luminal epithelial cell
 synonym: "luminal epithelial cell of the uterus" RELATED []
 relationship: part_of BTO:0006107 ! endometrial luminal epithelium
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-08-24T16:50:55Z
 
 [Term]
@@ -46699,7 +46716,7 @@ def: "A nucleus of nerve cells in the preoptic area of the basal forebrain, vent
 synonym: "lateral preoptic nucleus" RELATED []
 synonym: "nucleus praeopticus lateralis" RELATED []
 is_a: BTO:0003664 ! nucleus preopticus
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-09-03T10:03:26Z
 
 [Term]
@@ -46709,7 +46726,7 @@ def: "A nucleus of nerve cells in the preoptic area of the basal forebrain." [Do
 synonym: "medial preoptic nucleus" RELATED []
 synonym: "nucleus praeopticus medialis" RELATED []
 is_a: BTO:0003664 ! nucleus preopticus
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-09-03T10:07:38Z
 
 [Term]
@@ -46719,7 +46736,7 @@ def: "A nucleus of nerve cells in the preoptic area of the basal forebrain." [Do
 synonym: "median preoptic nucleus" RELATED []
 synonym: "nucleus praeopticus medianus" RELATED []
 is_a: BTO:0003664 ! nucleus preopticus
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-09-03T10:08:45Z
 
 [Term]
@@ -46729,7 +46746,7 @@ def: "A nucleus of nerve cells in the preoptic area of the basal forebrain." [Do
 synonym: "nucleus praeopticus periventricularis" RELATED []
 synonym: "periventricular preoptic nucleus" RELATED []
 is_a: BTO:0003664 ! nucleus preopticus
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-09-03T10:09:52Z
 
 [Term]
@@ -46737,17 +46754,17 @@ id: BTO:0006170
 name: nonpigmented ciliary epithelial cell
 synonym: "non-pigmented ciliary epithelial cell" RELATED []
 relationship: part_of BTO:0005893 ! nonpigmented ciliary epithelium
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-09-03T10:36:51Z
 
 [Term]
 id: BTO:0006171
 name: syncytial embryo sac
-def: "A stage of the embryo sac development." [curators:mgr]
+def: "A stage of the embryo sac development." []
 synonym: "syncytial female gametophyte" RELATED []
 synonym: "syncytial megagametophyte" RELATED []
 is_a: BTO:0000842 ! megagametophyte
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-09-03T13:34:24Z
 
 [Term]
@@ -46757,7 +46774,7 @@ def: "Somatic cell of the testis." [PMID:28957323]
 synonym: "somatic testicular cell" RELATED []
 synonym: "testis somatic cell" RELATED []
 relationship: part_of BTO:0001363 ! testis
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-09-03T13:51:13Z
 
 [Term]
@@ -46766,7 +46783,7 @@ name: trichilium
 def: "Trichome-covered tissue. Typically, the ventral petiole base of Cecropia leaves has a hairy mat, the trichilia, that produces glycogen-rich Muellerian bodies." [Brazilian_Journal_of_Botany:ISSN\:1806-9959, PMID:23632447]
 synonym: "leaf trichilum" RELATED []
 relationship: part_of BTO:0000718 ! leaf epidermis
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-09-03T14:22:32Z
 
 [Term]
@@ -46774,7 +46791,7 @@ id: BTO:0006174
 name: smooth adductor muscle
 is_a: BTO:0001262 ! soft body part
 relationship: part_of BTO:0001266 ! invertebrate muscular system
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-09-06T15:39:51Z
 
 [Term]
@@ -46785,7 +46802,7 @@ synonym: "gyrus temporalis inferior" RELATED []
 synonym: "inferior temporal convolution" RELATED []
 synonym: "third temporal convolution" RELATED []
 is_a: BTO:0006178 ! temporal gyrus
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-09-17T10:41:50Z
 
 [Term]
@@ -46796,7 +46813,7 @@ synonym: "gyrus temporalis medius" RELATED []
 synonym: "middle temporal convolution" RELATED []
 synonym: "second temporal convolution" RELATED []
 is_a: BTO:0006178 ! temporal gyrus
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-09-17T10:44:22Z
 
 [Term]
@@ -46807,7 +46824,7 @@ synonym: "first temporal convolution" RELATED []
 synonym: "gyrus temporalis superior" RELATED []
 synonym: "superior temporal convolution" RELATED []
 is_a: BTO:0006178 ! temporal gyrus
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-09-17T10:45:24Z
 
 [Term]
@@ -46816,7 +46833,7 @@ name: temporal gyrus
 def: "The superior, the middle, or the inferior temporal gyrus." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 is_a: BTO:0002495 ! cerebral gyrus
 relationship: part_of BTO:0001355 ! temporal lobe
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-09-17T10:47:22Z
 
 [Term]
@@ -46825,7 +46842,7 @@ name: cardiac tube
 def: "The primordial tubular heart in the embryo, before its division into chambers." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 synonym: "primitive heart tube" RELATED []
 relationship: develops_from BTO:0006180 ! endocardial heart tube
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-09-17T10:57:26Z
 
 [Term]
@@ -46833,7 +46850,7 @@ id: BTO:0006180
 name: endocardial heart tube
 def: "The two endothelial tubes that meet in the midthoracic region of the embryo and fuse to form the primordial cardiac or heart tube, the primordium of the heart." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 relationship: part_of BTO:0000379 ! embryo
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-09-17T10:59:36Z
 
 [Term]
@@ -46841,7 +46858,7 @@ id: BTO:0006181
 name: buffy coat
 def: "The buffy coat is the fraction of an anticoagulated blood sample that contains most of the white blood cells and platelets following density gradient centrifugation of the blood." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0001490 ! other source
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-09-17T11:02:34Z
 
 [Term]
@@ -46850,7 +46867,7 @@ name: venous blood cell
 def: "Blood cell found in the veins. Except in the pulmonary vein venous blood is rich in carbon dioxide and poor in oxygen." [Dictionary:http\://www.thefreedictionary.com/]
 is_a: BTO:0000574 ! hematopoietic cell
 relationship: part_of BTO:0006187 ! venous blood
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-09-17T11:04:22Z
 
 [Term]
@@ -46859,7 +46876,7 @@ name: arterial blood cell
 def: "Blood cell found in arteries. Except for the pulmonary artery the arterial blood is rich in oxygen." [Dictionary:http\://www.thefreedictionary.com/]
 is_a: BTO:0000574 ! hematopoietic cell
 relationship: part_of BTO:0006188 ! arterial blood
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-09-17T11:05:29Z
 
 [Term]
@@ -46868,7 +46885,7 @@ name: mouth floor
 def: "That area of the oral cavity beneath the tongue." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 synonym: "floor of mouth" RELATED []
 relationship: part_of BTO:0001090 ! mouth
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-09-17T11:08:37Z
 
 [Term]
@@ -46876,7 +46893,7 @@ id: BTO:0006185
 name: buffy coat cell
 def: "The buffy coat is the fraction of an anticoagulated blood sample that contains most of the white blood cells and platelets following density gradient centrifugation of the blood." [Wikipedia:The_Free_Encyclopedia]
 relationship: part_of BTO:0006181 ! buffy coat
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-09-17T11:58:42Z
 
 [Term]
@@ -46884,7 +46901,7 @@ id: BTO:0006186
 name: air pouch cell
 def: "An air pouch is produced by subcutaneous injection of sterile air into the back of a mouse or rat. With the air pouch model large volumes of inflammatory exudates can be collected with relative ease. Injection of carrageenan solution or other inflammatory irritant (i.e. LPS, bradykinin), into the air pouch causes an inflammatory reaction." [Washington_Biotechnology:http\://www.washingtonbiotech.com/inflammation_models/air_pouch_model.html]
 relationship: part_of BTO:0004045 ! air pouch
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-09-17T11:59:37Z
 
 [Term]
@@ -46892,7 +46909,7 @@ id: BTO:0006187
 name: venous blood
 def: "Blood found in the veins. Except in the pulmonary vein venous blood is rich in carbon dioxide and poor in oxygen." [Dictionary:http\://www.thefreedictionary.com/]
 is_a: BTO:0000089 ! blood
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-09-17T12:00:54Z
 
 [Term]
@@ -46900,7 +46917,7 @@ id: BTO:0006188
 name: arterial blood
 def: "Blood found in arteries. Except for the pulmonary artery the arterial blood is rich in oxygen." [Dictionary:http\://www.thefreedictionary.com/]
 is_a: BTO:0000089 ! blood
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-09-17T12:01:43Z
 
 [Term]
@@ -46908,7 +46925,7 @@ id: BTO:0006189
 name: protoperithecium
 def: "A primordium that when fertilized develops into a perithecium." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/protoperithecium]
 is_a: BTO:0002161 ! ascocarp
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-09-17T12:14:39Z
 
 [Term]
@@ -46917,7 +46934,7 @@ name: cybrid cell
 def: "A cell that has nuclear DNA from one source and cytoplasmic DNA from another, such as a nonhuman animal cell that has had its nucleus replaced by the nucleus of a human somatic cell." [Dictionary:http\://www.thefreedictionary.com/]
 synonym: "cytoplasmic hybrid cell" RELATED []
 is_a: BTO:0001490 ! other source
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-09-24T14:10:16Z
 
 [Term]
@@ -46927,7 +46944,7 @@ def: "The cumulus-oocyte complex is an oocyte surrounded by specialized granulos
 synonym: "COC cell" RELATED []
 is_a: BTO:0000410 ! immature ovarian follicle
 is_a: BTO:0000964 ! oocyte
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-09-24T14:24:32Z
 
 [Term]
@@ -46937,7 +46954,7 @@ def: "A glomus cell (type I) is a peripheral chemoreceptor, mainly located in th
 is_a: BTO:0005729 ! chemoreceptor cell
 relationship: part_of BTO:0000204 ! carotid body
 relationship: part_of BTO:0006193 ! aortic body
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-09-24T14:32:36Z
 
 [Term]
@@ -46945,7 +46962,7 @@ id: BTO:0006193
 name: aortic body
 def: "One of several small structures on the arch of the aorta that contain neural tissue sensitive to the chemical composition of arterial blood. The aortic bodies respond primarily to large reductions in blood oxygen content and trigger an increase in respiratory rate." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 is_a: BTO:0000135 ! aorta
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-09-24T14:35:47Z
 
 [Term]
@@ -46955,7 +46972,7 @@ def: "The aortic arch is the part of the aorta between the ascending and descend
 synonym: "arch of the aorta" RELATED []
 synonym: "transverse aortic arch" RELATED []
 is_a: BTO:0000135 ! aorta
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-09-24T14:37:29Z
 
 [Term]
@@ -46965,7 +46982,7 @@ def: "Chinese oesophaeal squamous cell carcinoma cell line." [PMID:29650964]
 synonym: "EC18 cell" RELATED []
 synonym: "EC18 OSCC cell" RELATED []
 is_a: BTO:0002428 ! esophageal squamous cell carcinoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-09-24T15:07:53Z
 
 [Term]
@@ -46973,7 +46990,7 @@ id: BTO:0006196
 name: vertebra
 def: "One of the bony or cartilaginous segments composing the spinal column, consisting in some lower vertebrates of several distinct elements which never become united, and in higher vertebrates having a short more or less cylindrical body whose ends articulate by pads of elastic or cartilaginous tissue with those of adjacent vertebrae and a bony arch that encloses the spinal cord." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/vertebra]
 relationship: part_of BTO:0000818 ! spinal column
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-09-24T16:06:36Z
 
 [Term]
@@ -46983,7 +47000,7 @@ def: "Human esophageal squamous cell carcinoma cell line; derived from the moder
 synonym: "KYSE 140 cell" RELATED []
 synonym: "KYSE140 cell" RELATED []
 is_a: BTO:0002428 ! esophageal squamous cell carcinoma cell line
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-09-24T15:20:51Z
 
 [Term]
@@ -46992,7 +47009,7 @@ name: esophageal epithelial cell line
 synonym: "NEEC cell line" RELATED []
 synonym: "normal esophageal epithelial cell line" RELATED []
 relationship: develops_from BTO:0001578 ! esophageal epithelium
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-09-24T15:25:05Z
 
 [Term]
@@ -47001,7 +47018,7 @@ name: esophageal epithelial cell
 synonym: "NEEC cell" RELATED []
 synonym: "normal esophageal epithelial cell" RELATED []
 relationship: part_of BTO:0001578 ! esophageal epithelium
-created_by: Marion, contact@brenda-enzymes.org
+created_by: Marion Gremse
 creation_date: 2018-09-24T15:27:59Z
 
 [Term]
@@ -47010,7 +47027,7 @@ name: 250MK cell
 def: "Normal human mammary epithelial cell line." [PMID:26687450]
 synonym: "250 MK cell" RELATED []
 is_a: BTO:0002768 ! mammary epithelial cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-09-25T09:18:44Z
 
 [Term]
@@ -47018,7 +47035,7 @@ id: BTO:0006201
 name: 3D4/21 cell
 def: "Sus scrofa lung alveolar macrophage cell line." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 is_a: BTO:0002889 ! alveolar macrophage cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-09-25T09:24:08Z
 
 [Term]
@@ -47026,7 +47043,7 @@ id: BTO:0006202
 name: 76NF2V cell
 def: "Human normal mammary epithelial cell line." [PMID:24412361]
 is_a: BTO:0002768 ! mammary epithelial cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-09-25T09:57:02Z
 
 [Term]
@@ -47035,7 +47052,7 @@ name: AML-193 cell
 def: "Human acute monocytic leukemia cell line, established from a 13 years old girl." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 synonym: "AML193 cell" RELATED []
 is_a: BTO:0002332 ! monocytic leukemia cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-09-25T10:13:57Z
 
 [Term]
@@ -47046,7 +47063,7 @@ comment: Recent evaluation of nude mouse tumors formed by this line in orthotopi
 synonym: "Caki 2 cell" RELATED []
 synonym: "Caki2 cell" RELATED []
 is_a: BTO:0000383 ! renal cell carcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-09-25T10:36:11Z
 
 [Term]
@@ -47055,7 +47072,7 @@ name: serotonergic neuron
 def: "A nerve cell that uses serotonin as its neurotransmitter." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 synonym: "serotonergic nerve" RELATED []
 is_a: BTO:0000938 ! neuron
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-09-25T11:07:18Z
 
 [Term]
@@ -47064,7 +47081,7 @@ name: extravillous cytotrophoblast
 def: "Extravillous cytotrophoblast cells are the cells of the outermost layer of the fetal component of the human placenta. The extravillous cytotrophoblast cells located proximal to the villous stroma are proliferating cells." [LifeMapSciences:https\://discovery.lifemapsc.com/in-vivo-development/placenta/extravillous-cytotrophoblast-layer/extravillous-cytotrophoblast-cells]
 synonym: "extravillus cytotrophoblast" RELATED []
 is_a: BTO:0000322 ! cytotrophoblast
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-09-25T11:11:41Z
 
 [Term]
@@ -47073,7 +47090,7 @@ name: extravillous cytotrophoblast cell
 def: "Extravillous cytotrophoblast cells are the cells of the outermost layer of the fetal component of the human placenta. The extravillous cytotrophoblast cells located proximal to the villous stroma are proliferating cells." [LifeMapSciences:https\://discovery.lifemapsc.com/in-vivo-development/placenta/extravillous-cytotrophoblast-layer/extravillous-cytotrophoblast-cells]
 synonym: "extravillus cytotrophoblast cell" RELATED []
 relationship: part_of BTO:0006206 ! extravillous cytotrophoblast
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-09-25T11:17:05Z
 
 [Term]
@@ -47084,7 +47101,7 @@ synonym: "EVT cell" RELATED []
 synonym: "intermediate trophoblast cell" RELATED []
 synonym: "interstitial trophoblast cell" RELATED []
 relationship: part_of BTO:0002366 ! extravillous trophoblast
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-09-25T11:15:32Z
 
 [Term]
@@ -47094,7 +47111,7 @@ def: "The cell line human invasive proliferative extravillous cytotrophoblast 65
 synonym: "HIPEC 65 cell" RELATED []
 synonym: "HIPEC65 cell" RELATED []
 is_a: BTO:0005020 ! cytotrophoblast cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-09-25T17:58:10Z
 
 [Term]
@@ -47103,7 +47120,7 @@ name: HMT-3522 T4-2 cell
 def: "This line is a subline that has been derived from HMT-3522. The parent line was established from a benign breast tumor of a 48 year old woman and has undergone spontaneous malignant transformation." [Sigma-Aldrich:http\://www.sigmaaldrich.com/]
 synonym: "HMT-3522/mt-1 cell" RELATED []
 relationship: develops_from BTO:0003884 ! HMT-3522 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-09-25T18:03:56Z
 
 [Term]
@@ -47113,7 +47130,7 @@ def: "Human thyroid carcinoma cell line, established from cancer cells dissemina
 synonym: "HTC C3 cell" RELATED []
 synonym: "HTCC3 cell" RELATED []
 is_a: BTO:0003209 ! anaplastic thyroid cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-09-25T18:06:28Z
 
 [Term]
@@ -47122,7 +47139,7 @@ name: HTR-8 cell
 def: "First trimester human trophoblast cell line. Parental cell line of HTR-8/SVneo." [PMID:7684692]
 synonym: "HTR8 cell" RELATED []
 is_a: BTO:0003420 ! trophoblast cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-09-25T18:24:39Z
 
 [Term]
@@ -47131,7 +47148,7 @@ name: KELLY cell
 def: "Human neuroblastoma cell line." [European_collection_of_cell_cultures:ECACC]
 synonym: "Kelly cell" RELATED []
 is_a: BTO:0000932 ! neuroblastoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-09-27T10:09:07Z
 
 [Term]
@@ -47140,7 +47157,7 @@ name: KIJ-265T cell
 def: "Clear cell renal cell carcinoma cell line, derived from primary tumor site stage 4 human ccRCC patient tissue." [PMID:22826467]
 synonym: "KIJ265T cell" RELATED []
 is_a: BTO:0000383 ! renal cell carcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-09-27T10:14:11Z
 
 [Term]
@@ -47149,7 +47166,7 @@ name: KIJ-308T cell
 def: "Clear cell renal cell carcinoma cell line." [PMID:27690003]
 synonym: "KIJ308T cell" RELATED []
 is_a: BTO:0000383 ! renal cell carcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-09-27T10:19:53Z
 
 [Term]
@@ -47157,7 +47174,7 @@ id: BTO:0006216
 name: leaf epidermal cell
 def: "Any of the cells in a leaf making up the epidermis." [Dictionary:http\://www.thefreedictionary.com/]
 relationship: part_of BTO:0000718 ! leaf epidermis
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-09-27T10:39:04Z
 
 [Term]
@@ -47166,7 +47183,7 @@ name: chondrogenic MCT cell
 def: "Mouse chondrocytes immortalized with a temperature-sensitive simian virus 40 large T antigen." [PMID:9990041]
 synonym: "MCT cell" RELATED []
 is_a: BTO:0003858 ! chondrocyte cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-09-27T11:20:06Z
 
 [Term]
@@ -47180,7 +47197,7 @@ synonym: "MDA-MB157 cell" RELATED []
 synonym: "MDA157 cell" RELATED []
 is_a: BTO:0001912 ! breast adenocarcinoma cell line
 is_a: BTO:0004086 ! mammary gland tumor cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-09-27T11:26:17Z
 
 [Term]
@@ -47188,7 +47205,7 @@ id: BTO:0006219
 name: neuromast
 def: "One of the characteristic sensory organs of the lateral lines of fishes and various other lower vertebrates consisting of a cluster of sensory cells connected with nerve fibers." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionaryneuromast]
 is_a: BTO:0000202 ! sense organ
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-09-27T11:53:24Z
 
 [Term]
@@ -47198,7 +47215,7 @@ def: "Human mammary gland ductal carcinoma cell line, established from breast ti
 synonym: "UACC 812 cell" RELATED []
 synonym: "UACC812 cell" RELATED []
 is_a: BTO:0004086 ! mammary gland tumor cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-09-27T15:28:39Z
 
 [Term]
@@ -47213,7 +47230,7 @@ synonym: "U343 MG cell" RELATED []
 synonym: "U343-MG cell" RELATED []
 is_a: BTO:0000711 ! glioma cell line
 relationship: develops_from BTO:0002036 ! U-87MG cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-09-27T15:41:35Z
 
 [Term]
@@ -47222,7 +47239,7 @@ name: olfactory placode
 def: "A thick plate of cells derived from the neural ectoderm in the head region of the vertebrate embryo and developing into the olfactory region of the nasal cavity." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/olfactory_placode]
 relationship: develops_from BTO:0006223 ! neural ectoderm
 relationship: part_of BTO:0004726 ! embryonic brain
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-09-27T16:14:38Z
 
 [Term]
@@ -47230,7 +47247,7 @@ id: BTO:0006223
 name: neural ectoderm
 def: "The part of the embryonic ectoderm that develops into the neural tube." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 is_a: BTO:0000315 ! ectoderm
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-09-27T16:16:47Z
 
 [Term]
@@ -47239,7 +47256,7 @@ name: OP-6 cell
 def: "Mouse olfactory placode cell line." [PMID:12093156]
 synonym: "OP6 cell" RELATED []
 is_a: BTO:0006225 ! olfactory placode cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-09-27T16:19:09Z
 
 [Term]
@@ -47249,7 +47266,7 @@ def: "A thick plate of cells derived from the neural ectoderm in the head region
 is_a: BTO:0002871 ! embryonic brain cell line
 relationship: develops_from BTO:0006222 ! olfactory placode
 relationship: develops_from BTO:0006223 ! neural ectoderm
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-09-27T16:18:28Z
 
 [Term]
@@ -47258,7 +47275,7 @@ name: OP-27 cell
 def: "Mouse olfactory placode cell line." [PMID:12093156]
 synonym: "OP27 cell" RELATED []
 is_a: BTO:0006225 ! olfactory placode cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-09-27T16:20:36Z
 
 [Term]
@@ -47268,7 +47285,7 @@ def: "Human lung squamous cell carcinoma cell line, established from a japanese 
 synonym: "LC-AI cell" RELATED []
 synonym: "RERF-LC-A1 cell" RELATED []
 is_a: BTO:0002202 ! lung squamous cell carcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-09-28T19:58:17Z
 
 [Term]
@@ -47278,7 +47295,7 @@ def: "Human myelodysplastic cell line. Myelodysplastic syndromes are a group of 
 synonym: "MDS 92 cell" RELATED []
 synonym: "MDS92 cell" RELATED []
 is_a: BTO:0000906 ! myeloid cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-09-28T20:20:36Z
 
 [Term]
@@ -47288,28 +47305,28 @@ def: "Human myelodysplastic syndrome-derived cell line. Myelodysplastic syndrome
 synonym: "MDS L cell" RELATED []
 synonym: "MDSL cell" RELATED []
 is_a: BTO:0000906 ! myeloid cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-09-28T20:22:51Z
 
 [Term]
 id: BTO:0006230
 name: culture condition:camphor-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-10-27T18:44:25Z
 
 [Term]
 id: BTO:0006231
 name: culture condition:(-)-camphor-grown cell
 is_a: BTO:0006230 ! culture condition:camphor-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-10-27T18:45:04Z
 
 [Term]
 id: BTO:0006232
 name: culture condition:(rac)-camphor-grown cell
 is_a: BTO:0006230 ! culture condition:camphor-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-10-27T18:45:48Z
 
 [Term]
@@ -47317,21 +47334,21 @@ id: BTO:0006233
 name: culture condition:dimethylsulphoniopropionate-grown cell
 synonym: "culture condition:dimethylsulfoniopropionate-grown cell" RELATED []
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-10-27T18:47:25Z
 
 [Term]
 id: BTO:0006234
 name: culture condition:nicotine-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-10-27T18:48:20Z
 
 [Term]
 id: BTO:0006235
 name: culture condition:rice bran-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-10-27T18:50:51Z
 
 [Term]
@@ -47339,14 +47356,14 @@ id: BTO:0006236
 name: culture condition:rice hull-grown cell
 synonym: "culture condition:rice husk-grown cell" RELATED []
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-10-27T18:51:06Z
 
 [Term]
 id: BTO:0006237
 name: culture condition:sugarcane bagasse-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-10-27T18:54:25Z
 
 [Term]
@@ -47355,7 +47372,7 @@ name: interfascicular cambium
 def: "The vascular cambium of a plant that develops between vascular bundles. A portion of vascular cambium that develops from cells in an interfascicular region that is part of a shoot system." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/, TAIR_The_Arabidopsis_Information_Resource:https\://www.arabidopsis.org/]
 is_a: BTO:0004502 ! vascular cambium
 relationship: develops_from BTO:0006239 ! interfascicular region
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-10-28T12:17:25Z
 
 [Term]
@@ -47363,7 +47380,7 @@ id: BTO:0006239
 name: interfascicular region
 def: "A portion of ground tissue located between vascular bundles in a shoot axis." [TAIR_The_Arabidopsis_Information_Resource:https\://www.arabidopsis.org/]
 relationship: part_of BTO:0001300 ! stem
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-10-28T12:41:03Z
 
 [Term]
@@ -47372,7 +47389,7 @@ name: PK-15CD163 cell
 def: "PK-15 cell line, transfected with porcine CD163 by PiggyBac transposon system." [PMID:23835031]
 synonym: "PK15CD163 cell" RELATED []
 relationship: develops_from BTO:0001865 ! PK-15 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2018-10-28T12:56:09Z
 
 [Term]
@@ -47380,7 +47397,7 @@ id: BTO:0006241
 name: endomysium
 def: "Endomysium, meaning within the muscle, is a wispy layer of areolar connective tissue that ensheaths each individual myocyte. It contains capillaries and nerves. It overlies the sarcolemma. Endomysium is the deepest and smallest component of muscle connective tissue." [Wikipedia:The_Free_Encyclopedia]
 relationship: part_of BTO:0001103 ! skeletal muscle
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-02-26T13:42:32Z
 
 [Term]
@@ -47388,7 +47405,7 @@ id: BTO:0006242
 name: external ectoderm
 synonym: "surface ectoderm" RELATED []
 relationship: part_of BTO:0000315 ! ectoderm
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-02-28T08:29:52Z
 
 [Term]
@@ -47396,7 +47413,7 @@ id: BTO:0006243
 name: bacteriocyte
 def: "A modified fat cell occurring in the fat body of certain insects and containing groups of bacterium-shaped rods that are believed to be symbiotic bacteria." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/bacteriocyte]
 is_a: BTO:0000443 ! adipocyte
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-02-28T08:37:52Z
 
 [Term]
@@ -47405,14 +47422,14 @@ name: blood-brain barrier
 def: "A layer of tightly packed unique endothelial cells that make up the walls of brain capillaries and prevent substances in the blood from diffusing freely into the brain." [Dictionary.com:https\://www.dictionary.com/]
 synonym: "blood-cerebral barrier" RELATED []
 relationship: part_of BTO:0006245 ! brain capillary endothelium
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-02-28T08:46:28Z
 
 [Term]
 id: BTO:0006245
 name: brain capillary endothelium
 relationship: part_of BTO:0003248 ! brain endothelium
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-02-28T09:04:18Z
 
 [Term]
@@ -47420,7 +47437,7 @@ id: BTO:0006246
 name: brain capillary endothelial cell
 is_a: BTO:0005201 ! brain endothelial cell
 relationship: part_of BTO:0006245 ! brain capillary endothelium
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-02-28T09:05:21Z
 
 [Term]
@@ -47428,7 +47445,7 @@ id: BTO:0006247
 name: culture condition:CD11c+ cell
 def: "CD11c is an integrin alpha X chain protein found at high levels on most human dendritic cells, but also on monocytes, macrophages, neutrophils, and some B cells that induces cellular activation and helps trigger neutrophil respiratory burst. It is expressed in hairy cell leukemias, acute nonlymphocytic leukemias, and some B-cell chronic lymphocytic leukemias." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0002008 ! culture condition:antigen-presenting cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-02-28T09:40:00Z
 
 [Term]
@@ -47436,7 +47453,7 @@ id: BTO:0006248
 name: dermatome
 def: "The lateral wall of a somite from which the dermis is produced." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/dermatome]
 relationship: part_of BTO:0001558 ! somite
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-02-28T09:45:14Z
 
 [Term]
@@ -47445,7 +47462,7 @@ name: dorsal endoderm
 def: "Single cell layer of involuted endoderm lying beneath the prechordal plate." [Xenopus_Anatomy_Ontology:http\://www.xenbase.org/anatomy/]
 xref: From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/dermatome
 is_a: BTO:0000800 ! endoderm
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-02-28T09:48:49Z
 
 [Term]
@@ -47453,7 +47470,7 @@ id: BTO:0006250
 name: epibranchial ganglion
 def: "Cranial ganglion which develops from an epibranchial placode." [ZFIN_Zebrafish_Information_Network:https\://zfin.org/action/ontology/https\://zfin.org/action/ontology/]
 is_a: BTO:0000106 ! cranial ganglion
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-02-28T09:52:41Z
 
 [Term]
@@ -47462,7 +47479,7 @@ name: renal proximal tubule cell
 synonym: "proximal tubule cell" RELATED []
 synonym: "renal proximal tubular cell" RELATED []
 relationship: part_of BTO:0001498 ! renal proximal tubule
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-02-28T11:01:44Z
 
 [Term]
@@ -47472,7 +47489,7 @@ synonym: "prostate epithelial cell" RELATED []
 synonym: "prostate gland epithelial cell" RELATED []
 synonym: "prostate gland epithelium cell" RELATED []
 relationship: part_of BTO:0002397 ! prostate gland epithelium
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-02-28T11:05:39Z
 
 [Term]
@@ -47482,7 +47499,7 @@ def: "Human ovarian carcinoma cell line; established from a 56-years-old female.
 synonym: "UWB1-289 cell" RELATED []
 synonym: "UWB1289 cell" RELATED []
 is_a: BTO:0000811 ! ovary cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-02-28T11:21:16Z
 
 [Term]
@@ -47490,7 +47507,7 @@ id: BTO:0006254
 name: UWB1.289+BRCA1 cell
 def: "A stable cell line derived from UWB1.289." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 relationship: develops_from BTO:0006253 ! UWB1.289 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-02-28T11:24:35Z
 
 [Term]
@@ -47498,7 +47515,7 @@ id: BTO:0006255
 name: sclerotome
 def: "The lower, medioventral part of the somite, that breaks up into mesenchyme, which contributes to the axial skeleton of the embryo, that is the vertebral column, ribs, and much of the skull." [Encyclopedia_Britannica:http\://www.britannica.com/]
 relationship: part_of BTO:0001558 ! somite
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-02-28T12:06:55Z
 
 [Term]
@@ -47507,7 +47524,7 @@ name: solid cancer cell
 def: "An abnormal mass of tissue that usually does not contain cysts or liquid areas. Solid tumors may be benign, or malignant. Different types of solid tumors are named for the type of cells that form them. Examples of solid tumors are sarcomas, carcinomas, and lymphomas. Leukemias  generally do not form solid tumors." [NCI_Dictionary_of_Cancer_Term:https\://www.cancer.gov]
 synonym: "solid tumor cell" RELATED []
 is_a: BTO:0000284 ! organism form
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-02T11:11:33Z
 
 [Term]
@@ -47515,7 +47532,7 @@ id: BTO:0006257
 name: oral sucker
 def: "A mouth, as of a leech, adapted for sucking or adhering." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/sucker]
 is_a: BTO:0001262 ! soft body part
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-02T18:13:14Z
 
 [Term]
@@ -47523,7 +47540,7 @@ id: BTO:0006258
 name: ventral sucker
 def: "A mouth, as of a leech, adapted for sucking or adhering." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/sucker]
 is_a: BTO:0001262 ! soft body part
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-02T18:14:14Z
 
 [Term]
@@ -47531,7 +47548,7 @@ id: BTO:0006259
 name: pluteus
 def: "The free-swimming, bilaterally symmetrical larva of an echinoid or ophiuroid." [Dictionary.com:https\://www.dictionary.com/]
 is_a: BTO:0000707 ! larva
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-02T18:40:42Z
 
 [Term]
@@ -47540,7 +47557,7 @@ name: GM02784 cell
 def: "Human fibroblast cell line." [PMID:27743858]
 synonym: "GMO2784 cell" RELATED []
 is_a: BTO:0000453 ! fibroblast cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-03T12:49:11Z
 
 [Term]
@@ -47552,14 +47569,14 @@ synonym: "HL-60-S cell" RELATED []
 synonym: "HL60(S) cell" RELATED []
 synonym: "HL60/S cell" RELATED []
 relationship: develops_from BTO:0000738 ! HL-60 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-03T13:12:03Z
 
 [Term]
 id: BTO:0006262
 name: thymic cancer cell line
 relationship: develops_from BTO:0001460 ! thymic cancer cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-03T13:30:45Z
 
 [Term]
@@ -47567,7 +47584,7 @@ id: BTO:0006263
 name: IT-79MTNC3 cell
 def: "Mouse thymic tumor cell line." [JCRB_Japanese_Collection_of_Research_Bioresources:http\://cellbank.nibio.go.jp./]
 is_a: BTO:0006262 ! thymic cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-03T13:31:05Z
 
 [Term]
@@ -47577,7 +47594,7 @@ def: "An androgen-independent cell line derived from the parental LNCaP cell lin
 synonym: "LNCaP 95 cell" RELATED []
 synonym: "LNCaP95 cell" RELATED []
 relationship: develops_from BTO:0001321 ! LNCaP cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-03T13:33:38Z
 
 [Term]
@@ -47589,7 +47606,7 @@ synonym: "ENZR 49F cell" RELATED []
 synonym: "ENZR49F cell" RELATED []
 synonym: "MR49-F cell" RELATED []
 relationship: develops_from BTO:0001321 ! LNCaP cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-03T13:38:09Z
 
 [Term]
@@ -47598,7 +47615,7 @@ name: subfornical organ
 def: "A small tubercle in the floor of the third ventricle. The intercolumnar tubercle. One of the circumventricular organs. It has fenestrated capillaries and is outside the blood-brain barrier. It is thought to be a chemoreceptor zone involved in cardiovascular regulation." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 synonym: "organum subfornicale" RELATED []
 is_a: BTO:0006267 ! circumventricular organ
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-04T12:44:38Z
 
 [Term]
@@ -47606,7 +47623,7 @@ id: BTO:0006267
 name: circumventricular organ
 def: "Four small areas in or near the base of the brain that have fenestrated capillaries and are outside the blood-brain barrier. They are the neurohypophysis, the area postrema, the organum vasculosum of the lamina terminalis, and the subfornical organ. The neurohypophysis is a neurohemal organ. The other three are chemoreceptors: the area postrema triggers vomiting in response to chemical changes in plasma, the organum vasculosum of the lamina terminalis senses osmolality and alters vasopressin secretion, and the subfornical organ initiates drinking in response to angiotensin II." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 relationship: part_of BTO:0001442 ! brain ventricle
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-04T12:48:29Z
 
 [Term]
@@ -47617,7 +47634,7 @@ synonym: "organum vasculosum of the lamina terminalis" RELATED []
 synonym: "supraoptic crest" RELATED []
 synonym: "vascular organ of lamina terminalis" RELATED []
 is_a: BTO:0006267 ! circumventricular organ
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-04T12:52:14Z
 
 [Term]
@@ -47626,7 +47643,7 @@ name: ACI-45 cell
 def: "Uterine carcinosarcoma cell line." [PMID:21882256]
 synonym: "ACI45 cell" RELATED []
 is_a: BTO:0006270 ! uterine carcinosarcoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-04T13:21:52Z
 
 [Term]
@@ -47634,7 +47651,7 @@ id: BTO:0006270
 name: uterine carcinosarcoma cell line
 def: "A malignant tumor cell line combining elements of carcinoma and sarcoma in the uterus." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/carcinosarcoma]
 is_a: BTO:0003596 ! uterine sarcoma cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-04T13:23:44Z
 
 [Term]
@@ -47642,7 +47659,7 @@ id: BTO:0006271
 name: endometrial gland cell line
 relationship: develops_from BTO:0003433 ! endometrial gland
 relationship: develops_from BTO:0006108 ! endometrial glandular epithelium
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-04T13:28:07Z
 
 [Term]
@@ -47651,7 +47668,7 @@ name: EM-E6E7TERT-1 cell
 def: "Immortalized endometrial glandular cells with normal structural and functional characteristics." [PMID:14633600]
 synonym: "EM E6/E7 TERT1 cell" RELATED []
 is_a: BTO:0006271 ! endometrial gland cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-04T13:28:30Z
 
 [Term]
@@ -47660,7 +47677,7 @@ name: EM-E6E7TERT-2 cell
 def: "Immortalized endometrial glandular cells with normal structural and functional characteristics." [PMID:14633600]
 synonym: "EM E6/E7 TERT2 cell" RELATED []
 is_a: BTO:0006271 ! endometrial gland cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-04T13:37:58Z
 
 [Term]
@@ -47669,7 +47686,7 @@ name: EM-E6E7TERT-3 cell
 def: "Immortalized endometrial glandular cells with normal structural and functional characteristics." [PMID:14633600]
 synonym: "EM E6/E7 TERT3 cell" RELATED []
 is_a: BTO:0006271 ! endometrial gland cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-04T13:38:14Z
 
 [Term]
@@ -47679,7 +47696,7 @@ def: "Intrinsic CDDP resistant human non-small-cell lung cancer cell line." [PMI
 synonym: "S1 cell" RELATED []
 synonym: "SW1573/S1 cell" RELATED []
 relationship: develops_from BTO:0003016 ! SW-1573 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-04T18:13:22Z
 
 [Term]
@@ -47687,7 +47704,7 @@ id: BTO:0006276
 name: GNET cell
 synonym: "gastric neuroendocrine tumor cell" RELATED []
 is_a: BTO:0001407 ! neuroendocrine tumor cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-04T18:19:45Z
 
 [Term]
@@ -47695,7 +47712,7 @@ id: BTO:0006277
 name: outer mantle
 def: "Besides pigments, the outer mantle of the giant clam Tridacna squamosa has iridophores which consist of small groups of cells containing stacks of tiny platelets .The reflective platelets scatter light of photosynthetically productive wavelengths into the tissue while back-reflecting non-productive wavelength. Thus, the extensible outer mantle is brightly colored." [PMID:29066980]
 relationship: part_of BTO:0000825 ! mantle
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-04T18:26:20Z
 
 [Term]
@@ -47703,7 +47720,7 @@ id: BTO:0006278
 name: inner mantle
 def: "The inner mantle of the giant clam Tridacna squamosa, adjacent to the extrapallial fluid, as demarcated by the pallial line of the shell-valve, is thin and whitish, and is involved in shell formation." [PMID:29066980]
 relationship: part_of BTO:0000825 ! mantle
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-04T18:26:46Z
 
 [Term]
@@ -47711,7 +47728,7 @@ id: BTO:0006279
 name: tubulointerstitium
 def: "The tubules and interstitial tissue of the kidneys." [YourDictionary:https\://www.yourdictionary.com/]
 is_a: BTO:0000671 ! kidney
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-04T18:41:58Z
 
 [Term]
@@ -47723,7 +47740,7 @@ synonym: "ampulla of ductus deferens" RELATED []
 synonym: "ampulla of vas deferens" RELATED []
 synonym: "ductus deferens ampulla" RELATED []
 relationship: part_of BTO:0001427 ! vas deferens
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-04T18:44:55Z
 
 [Term]
@@ -47733,7 +47750,7 @@ def: "Human hepatocellular carcinoma cell line." [PMID:23187001]
 synonym: "Yy 8103 cell" RELATED []
 synonym: "YY-8103 HCC cell" RELATED []
 is_a: BTO:0000578 ! hepatoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-07T10:20:27Z
 
 [Term]
@@ -47745,21 +47762,21 @@ synonym: "Tig3 cell" RELATED []
 synonym: "Tokyo Institute of Gerontology-3 cell" RELATED []
 is_a: BTO:0000161 ! lung fibroblast cell line
 is_a: BTO:0001958 ! embryonic fibroblast cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-07T10:39:53Z
 
 [Term]
 id: BTO:0006283
 name: prechordal mesendoderm
 is_a: BTO:0003953 ! mesendoderm
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-07T11:08:29Z
 
 [Term]
 id: BTO:0006284
 name: root nodule cortex
 relationship: part_of BTO:0001190 ! root nodule
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-07T11:50:28Z
 
 [Term]
@@ -47767,7 +47784,7 @@ id: BTO:0006285
 name: SPC-A4 cell
 def: "Human lung adenocarcinoma cell line." [PMID:16082187]
 is_a: BTO:0001911 ! lung adenocarcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-08T10:59:31Z
 
 [Term]
@@ -47778,7 +47795,7 @@ synonym: "disc flower" RELATED []
 synonym: "disk floret" RELATED []
 synonym: "disk flower" RELATED []
 is_a: BTO:0000468 ! floret
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-21T18:07:41Z
 
 [Term]
@@ -47790,7 +47807,7 @@ synonym: "MGH-U3 (RN) cell" RELATED []
 synonym: "MGHU3 cell" RELATED []
 synonym: "RN cell" RELATED []
 is_a: BTO:0000792 ! urinary bladder carcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-21T19:12:48Z
 
 [Term]
@@ -47802,7 +47819,7 @@ synonym: "MGH-U4 (RB) cell" RELATED []
 synonym: "MGHU4 cell" RELATED []
 synonym: "RB cell" RELATED []
 is_a: BTO:0000792 ! urinary bladder carcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-21T19:21:06Z
 
 [Term]
@@ -47810,7 +47827,7 @@ id: BTO:0006289
 name: Vero 2.2 cell
 def: "A derivative of Vero cells." [PMID:15892968]
 relationship: develops_from BTO:0001444 ! Vero cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-23T19:16:41Z
 
 [Term]
@@ -47822,7 +47839,7 @@ synonym: "UM-UC2 cell" RELATED []
 synonym: "UMUC-2 cell" RELATED []
 synonym: "University of Michigan-Urothelial Carcinoma-2 cell" RELATED []
 relationship: develops_from BTO:0001345 ! T-24 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-23T19:24:39Z
 
 [Term]
@@ -47830,7 +47847,7 @@ id: BTO:0006291
 name: Mbeta16tsA cell
 def: "Wild-type mouse embryonic fibroblast cell line Mbeta16tsA." [PMID:10636928]
 is_a: BTO:0001958 ! embryonic fibroblast cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-03-23T19:53:33Z
 
 [Term]
@@ -47840,14 +47857,14 @@ def: "Aedes aegypti derived clonal mosquito cell line; derived from a neonate mo
 synonym: "Aag2 cell" RELATED []
 synonym: "Pelegs line 59 cell" RELATED []
 is_a: BTO:0000669 ! embryonic cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-09-20T19:52:22Z
 
 [Term]
 id: BTO:0006293
 name: breast cancer stem cell
 is_a: BTO:0004254 ! cancer stem cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-09-20T19:57:36Z
 
 [Term]
@@ -47855,7 +47872,7 @@ id: BTO:0006294
 name: BWZ.36 cell
 def: "Mouse lymphoma cell line, derived by transfecting alpha-beta-BW5147 cells with the NFAT-lacZ construct." [PMID:8186188]
 relationship: develops_from BTO:0000791 ! BW-5147 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-09-21T12:23:49Z
 
 [Term]
@@ -47865,7 +47882,7 @@ def: "Mouse lymphoma cell line, derived by transfecting alpha-beta-BW5147 cells 
 synonym: "BWZ.36.CD8 alpha" RELATED []
 synonym: "BWZ.36/CD8alpha" RELATED []
 relationship: develops_from BTO:0000791 ! BW-5147 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-09-21T12:26:53Z
 
 [Term]
@@ -47875,7 +47892,7 @@ def: "Either of a pair of collateral sympathetic ganglia that are the largest of
 synonym: "ganglion celiacum" RELATED []
 synonym: "ganglion coeliacum" RELATED []
 is_a: BTO:0001333 ! sympathetic ganglion
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-09-21T12:51:52Z
 
 [Term]
@@ -47883,7 +47900,7 @@ id: BTO:0006297
 name: CH12F3 cell
 def: "Mouse B-lymphocyte cell line." [Kerafast:https\://www.kerafast.com]
 relationship: develops_from BTO:0002493 ! CH12.LX cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-09-21T12:56:47Z
 
 [Term]
@@ -47898,7 +47915,7 @@ synonym: "HepG2 AD38 cell" RELATED []
 synonym: "HepG2-AD38 cell" RELATED []
 is_a: BTO:0001664 ! hepatoblastoma cell line
 relationship: develops_from BTO:0000599 ! Hep-G2 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-09-21T17:15:45Z
 
 [Term]
@@ -47907,7 +47924,7 @@ name: gastric cecum
 def: "One of the elongated pouches projecting from the upper end of the insect stomach." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/gastric cecum]
 synonym: "gastric caecum" RELATED []
 is_a: BTO:0000166 ! cecum
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-09-27T15:03:32Z
 
 [Term]
@@ -47917,7 +47934,7 @@ def: "Preparation resulting from the lysis of erythrocytes." [Medical_Dictionary
 synonym: "haemolysate" RELATED []
 is_a: BTO:0004304 ! cell lysate
 relationship: disease_arises_from_structure BTO:0000424 ! erythrocyte
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-09-27T18:34:20Z
 
 [Term]
@@ -47928,7 +47945,7 @@ synonym: "Hep-N10 cell" RELATED []
 synonym: "HepN10 cell" RELATED []
 synonym: "N10 cell" RELATED []
 relationship: develops_from BTO:0000599 ! Hep-G2 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-09-27T18:55:15Z
 
 [Term]
@@ -47937,7 +47954,7 @@ name: mpkCCD cell
 def: "Mouse cortical collecting duct cell line." [PMID:29070569]
 is_a: BTO:0002658 ! collecting duct cell line
 relationship: develops_from BTO:0004537 ! cortical collecting duct cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-09-29T12:33:01Z
 
 [Term]
@@ -47945,7 +47962,7 @@ id: BTO:0006303
 name: Mull cell
 def: "Human melanoma cell line." [PMID:30674989]
 is_a: BTO:0000849 ! melanoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-09-29T12:42:16Z
 
 [Term]
@@ -47953,7 +47970,7 @@ id: BTO:0006304
 name: JC cell
 def: "Mouse mammary gland adenocarcinoma cell line." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 is_a: BTO:0004086 ! mammary gland tumor cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-09-29T12:45:24Z
 
 [Term]
@@ -47962,7 +47979,7 @@ name: rhizodermis
 def: "The outermost primary cell layer of the root." [YourDictionary:https\://www.yourdictionary.com/]
 is_a: BTO:0000116 ! plant epidermis
 relationship: part_of BTO:0001188 ! root
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-09-29T12:57:20Z
 
 [Term]
@@ -47971,7 +47988,7 @@ name: stichosome
 def: "A column of glandular cells associated with the esophagus of various nematodes." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/stichosome]
 is_a: BTO:0000522 ! gland
 relationship: part_of BTO:0000959 ! esophagus
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-09-29T13:12:56Z
 
 [Term]
@@ -47981,7 +47998,7 @@ def: "Urinary bladder transitional cell carcinoma cell line; established in 1974
 synonym: "SW 780 cell" RELATED []
 synonym: "SW780 cell" RELATED []
 is_a: BTO:0002868 ! urinary bladder transitional cell carcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-09-29T13:33:20Z
 
 [Term]
@@ -47990,7 +48007,7 @@ name: TCC-SUP cell
 def: "Urinary bladder transitional cell carcinoma cell line; established from the tumor spediment resected from the undifferentiated grade IV urinary bladder transitional cell carcinoma of a 67-year-old woman in 1974." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 synonym: "TCCSUP cell" RELATED []
 is_a: BTO:0002868 ! urinary bladder transitional cell carcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-09-29T13:35:59Z
 
 [Term]
@@ -47998,7 +48015,7 @@ id: BTO:0006309
 name: WIF-B9 cell
 def: "Rat hepatoma/human fibroblast hybrid cell line." [PMID:17276572]
 relationship: develops_from BTO:0005889 ! WIF-B cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-09-29T13:48:27Z
 
 [Term]
@@ -48006,7 +48023,7 @@ id: BTO:0006310
 name: WIF-B9/R cell
 def: "Subline of WIF-B9 cell line, obtained by exposure to progressively increasing cisplatin concentrations and double sub-clonal selection." [PMID:17276572]
 relationship: develops_from BTO:0006309 ! WIF-B9 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-09-29T13:50:31Z
 
 [Term]
@@ -48016,7 +48033,7 @@ def: "Normal human lung fibroblast cell line." [PMID:28318075]
 comment: Is a synonym of BTO:0003066, name: WI38-VA13 subline 2RA cell.
 synonym: "WI38 VA13 cell" RELATED []
 is_obsolete: true
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-09-29T14:05:49Z
 
 [Term]
@@ -48027,7 +48044,7 @@ synonym: "musculus plantaris" RELATED []
 synonym: "plantar muscle" RELATED []
 synonym: "plantaris" RELATED []
 is_a: BTO:0000722 ! leg muscle
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-09-29T14:19:49Z
 
 [Term]
@@ -48035,7 +48052,7 @@ id: BTO:0006313
 name: taproot
 def: "Main root of a primary root system, growing vertically downward. Most dicotyledonous plants, such as dandelions, produce taproots, and some, such as the edible roots of carrots and beets, are specialized for food storage." [Encyclopedia_Britannica:http\://www.britannica.com/]
 is_a: BTO:0001188 ! root
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-09-29T14:26:20Z
 
 [Term]
@@ -48044,7 +48061,7 @@ name: shell capitulum
 def: "Pedunculate, goose or goose-neck barnacles have a flexible, muscular stalk, known as the peduncle, which supports the main body known as the capitulum. In Pollicipes pollicipes the capitulum is triangular in nature and white-grey in colour. A number of plates of different sizes protect the capitulum, increasing to over 100 in number with age. The plates may reach up to 0.5 mm in length. Six pairs of thin, feather-like cirri can be seen to arise from within the mantle cavity and are used for feeding." [MarLIN:The_Marine_Life_Information_Network]
 synonym: "mussel capitulum" RELATED []
 is_a: BTO:0001262 ! soft body part
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-10-05T09:15:37Z
 
 [Term]
@@ -48053,7 +48070,7 @@ name: shell peduncle
 def: "Pedunculate, goose or goose-neck barnacles have a flexible, muscular stalk, known as the peduncle, which supports the main body known as the capitulum. In Pollicipes pollicipes the peduncle may reach over 10 cm in length and is strongly attached to the substratum despite repeated battering in exposed conditions." [MarLIN:The_Marine_Life_Information_Network]
 synonym: "mussel peduncle" RELATED []
 is_a: BTO:0001262 ! soft body part
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-10-05T09:19:10Z
 
 [Term]
@@ -48061,7 +48078,7 @@ id: BTO:0006316
 name: compound leaf
 def: "A leaf in which the blade is divided to the midrib, forming two or more distinct blades or leaflets on a common axis, the leaflets themselves occasionally being compound." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/compound leaf]
 is_a: BTO:0000713 ! leaf
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-10-05T11:52:13Z
 
 [Term]
@@ -48069,7 +48086,7 @@ id: BTO:0006317
 name: plant rachis
 def: "The main axis or stem of an inflorescence or compound leaf." [Dictionary:http\://www.thefreedictionary.com/]
 relationship: part_of BTO:0001461 ! whole plant
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-10-05T11:52:35Z
 
 [Term]
@@ -48077,7 +48094,7 @@ id: BTO:0006318
 name: culture condition:beech wood-grown cell
 def: "Is a substrate for basidiomycetes." [Labor&more:http\://www.laborundmore.com/archive/375929/Neue-Biokatalysatoren-aus-Basidiomyceten.html]
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-10-10T09:21:50Z
 
 [Term]
@@ -48085,7 +48102,7 @@ id: BTO:0006319
 name: culture condition:wheat straw-grown cell
 def: "Is a substrate for basidiomycetes." [Labor&more:http\://www.laborundmore.com/archive/375929/Neue-Biokatalysatoren-aus-Basidiomyceten.html]
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-10-10T09:29:46Z
 
 [Term]
@@ -48093,7 +48110,7 @@ id: BTO:0006320
 name: HKiG2 cell
 def: "cN-II hyper-expressing cell line derived from human embryonic kidney HEK 293 cells." [PMID:25857773]
 relationship: develops_from BTO:0000007 ! HEK-293 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-10-10T09:55:16Z
 
 [Term]
@@ -48104,7 +48121,7 @@ synonym: "GC-1 cell" RELATED []
 synonym: "GC-1spg cell" RELATED []
 synonym: "GC1-SPG cell" RELATED []
 is_a: BTO:0004229 ! testicular cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2019-10-10T10:08:05Z
 
 [Term]
@@ -48115,28 +48132,28 @@ synonym: "HEK293 Jump-In T-REx cell" RELATED []
 synonym: "Jump-In 293 T-Rex cell" RELATED []
 synonym: "Jump-In-T-REx cell" RELATED []
 relationship: develops_from BTO:0005238 ! T-REx 293 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-01-03T14:23:28Z
 
 [Term]
 id: BTO:0006323
 name: culture condition:itaconate-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-01-05T19:28:20Z
 
 [Term]
 id: BTO:0006324
 name: culture condition:mesaconate-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-01-05T19:29:20Z
 
 [Term]
 id: BTO:0006325
 name: culture condition:chlorobenzene-grown cell
 is_a: BTO:0001479 ! culture condition:-grown cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-01-18T13:43:11Z
 
 [Term]
@@ -48145,7 +48162,7 @@ name: A2780/AD cell
 def: "A variant of A2780 human ovarian cancer cell line, resistant to doxorubicin." [PMID:7927910]
 synonym: "A2780AD cell" RELATED []
 relationship: develops_from BTO:0002549 ! A-2780 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-01-18T13:49:16Z
 
 [Term]
@@ -48154,7 +48171,7 @@ name: Phoenix-AMPHO cell
 def: "EK 293T/17 cells were transformed with adenovirus E1a carrying a temperature sensitive T antigen co-selected with neomycin." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 synonym: "Phoenix A cell" RELATED []
 relationship: develops_from BTO:0006328 ! HEK-293T/17 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-27T11:35:17Z
 
 [Term]
@@ -48165,7 +48182,7 @@ synonym: "293T/17 cell" RELATED []
 synonym: "HEK 293T/17 cell" RELATED []
 synonym: "HEK293T/17 cell" RELATED []
 relationship: develops_from BTO:0002181 ! HEK-293T cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-27T11:37:29Z
 
 [Term]
@@ -48174,7 +48191,7 @@ name: red nucleus
 def: "The red nucleus or nucleus ruber is a structure in the rostral midbrain involved in motor coordination." [Wikipedia:The_Free_Encyclopedia]
 synonym: "nucleus ruber" RELATED []
 relationship: part_of BTO:0000138 ! midbrain
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-27T11:42:16Z
 
 [Term]
@@ -48182,7 +48199,7 @@ id: BTO:0006330
 name: proglottid
 def: "Any of the segments of a tapeworm; they contain both male and female reproductive organs." [Wiktionary:https\://en.wiktionary.org/wiki/]
 relationship: part_of BTO:0006331 ! strobila
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-27T11:46:02Z
 
 [Term]
@@ -48190,7 +48207,7 @@ id: BTO:0006331
 name: strobila
 def: "The sum of the proglottids is called a strobila, which is thin and resembles a strip of tape." [Wiktionary:https\://en.wiktionary.org/wiki/]
 relationship: part_of BTO:0005278 ! cestode
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-27T11:48:21Z
 
 [Term]
@@ -48200,7 +48217,7 @@ def: "Human pediatric GBM-derived cell line." [PMID:29129566]
 synonym: "SJ-GBM2 cell" RELATED []
 synonym: "SJGBM2 cell" RELATED []
 is_a: BTO:0005949 ! glioblastoma multiforme cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-27T11:51:18Z
 
 [Term]
@@ -48209,7 +48226,7 @@ name: BM7 cell
 def: "Human lung adenocarcinoma cell line. A brain-metastatic clone derived from a high metastatic subline F4, which had higher invasion capability than its parental cell line CL1-0." [PMID:24705471]
 synonym: "Bm7cell" RELATED []
 relationship: develops_from BTO:0006343 ! CL1-5-F4 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-27T12:37:30Z
 
 [Term]
@@ -48217,7 +48234,7 @@ id: BTO:0006334
 name: uterine endometrial clear cell carcinoma cell line
 synonym: "EM CCC cell line" RELATED []
 is_a: BTO:0001555 ! endometrial cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-28T08:52:55Z
 
 [Term]
@@ -48225,7 +48242,7 @@ id: BTO:0006335
 name: TMG-L cell
 def: "Human uterine endometrial undifferentiated carcinoma cell line; established from the metastatic lymph node of 56 year old patient." [PMID:12971623]
 is_a: BTO:0006334 ! uterine endometrial clear cell carcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-28T08:53:35Z
 
 [Term]
@@ -48233,7 +48250,7 @@ id: BTO:0006336
 name: TMCC-2 cell
 def: "Human endometrial clear cell carcinoma cell line; established from operation material from a woman with endometrial clear cell carcinoma." [PMID:1890355]
 is_a: BTO:0006334 ! uterine endometrial clear cell carcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-28T08:55:56Z
 
 [Term]
@@ -48246,7 +48263,7 @@ synonym: "endometrial clear cell carcinoma cell" RELATED []
 synonym: "endometrial clear cell-carcinoma cell" RELATED []
 synonym: "uterine endometrial clear-cell carcinoma cell" RELATED []
 is_a: BTO:0003871 ! uterine endometrial cancer cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-28T08:58:14Z
 
 [Term]
@@ -48254,7 +48271,7 @@ id: BTO:0006338
 name: excretory system
 def: "Four distinctive cell types make up the excretory system of the worm Caenorhabditis elegans: one pore cell, one duct cell, one canal cell and a fused pair of gland cells." [Wormatlas:http\://www.wormatlas.org/]
 is_a: BTO:0001806 ! visceral mass
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-28T09:24:27Z
 
 [Term]
@@ -48263,7 +48280,7 @@ name: excretory pore cell
 def: "The pore cell is a specialized, transitional, epithelial cell. It encloses the ventral third of the duct and forms an adherens junction with the duct cell at the duct cell-pore cell junction." [Wormatlas:http\://www.wormatlas.org/]
 synonym: "pore cell" RELATED []
 relationship: part_of BTO:0006338 ! excretory system
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-28T09:27:14Z
 
 [Term]
@@ -48272,7 +48289,7 @@ name: excretory duct cell
 def: "The duct cell surrounds the duct from its origin to the boundary of the pore cell and is located just anterior and lateral (left or right) to the excretory cell body." [Wormatlas:http\://www.wormatlas.org/]
 synonym: "duct cell" RELATED []
 relationship: part_of BTO:0006338 ! excretory system
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-28T09:29:28Z
 
 [Term]
@@ -48280,7 +48297,7 @@ id: BTO:0006341
 name: excretory duct
 def: "The excretory duct of Caenorhabditis elegans is a 15 micrometer long, cuticle-lined channel that connects the excretory system to outside via the excretory pore located at midline on the ventral side of the body." [Wormatlas:http\://www.wormatlas.org/]
 relationship: part_of BTO:0006338 ! excretory system
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-28T09:31:59Z
 
 [Term]
@@ -48289,7 +48306,7 @@ name: excretory gland cell
 def: "Gland cell of the secretory-excretory system, sends processes to ring, opens into excretory duct." [Wormbase:https\://wormbase.org//species/all/anatomy_term/]
 synonym: "worm excretory gland cell" RELATED []
 relationship: part_of BTO:0006338 ! excretory system
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-28T09:37:48Z
 
 [Term]
@@ -48301,7 +48318,7 @@ synonym: "CL1-5F4 cell" RELATED []
 synonym: "F4 cell" RELATED []
 synonym: "lung cancer F4 cell" RELATED []
 relationship: develops_from BTO:0002876 ! CL1-5 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-28T10:13:09Z
 
 [Term]
@@ -48310,7 +48327,7 @@ name: ovarian follicle layer
 def: "A monolayer of follicle cells surrounding the developing oocyte and forming adhesive contacts with the surrounding follicular epithelium." [XenopusAnatomyOntology:https\://www.xenbase.org/anatomy/]
 synonym: "follicle layer" RELATED []
 relationship: part_of BTO:0000475 ! ovarian follicle
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-28T11:04:46Z
 
 [Term]
@@ -48318,7 +48335,7 @@ id: BTO:0006345
 name: glioblastoma multiforme cancer stem cell
 synonym: "GBM CSC cell" RELATED []
 is_a: BTO:0004254 ! cancer stem cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-28T11:15:08Z
 
 [Term]
@@ -48328,7 +48345,7 @@ def: "A cell of the vitellarium." [Wiktionary:https\://en.wiktionary.org/wiki/]
 synonym: "Dotterzelle" RELATED GE []
 synonym: "vitelline cell" RELATED []
 relationship: part_of BTO:0004242 ! vitellarium
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-28T11:54:54Z
 
 [Term]
@@ -48336,7 +48353,7 @@ id: BTO:0006347
 name: neoblast
 def: "Any large and undifferentiated stem cell in certain worms, esp planarian worms, involved in regeneration and repair." [Dictionary:http\://www.thefreedictionary.com/]
 is_a: BTO:0006078 ! pluripotent stem cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-29T16:25:22Z
 
 [Term]
@@ -48347,7 +48364,7 @@ synonym: "spermatogonial stem cell" RELATED []
 synonym: "SSC cell" RELATED []
 is_a: BTO:0000958 ! spermatogonium
 is_a: BTO:0002666 ! adult stem cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-29T16:33:37Z
 
 [Term]
@@ -48356,7 +48373,7 @@ name: type B spermatogonium
 def: "Type B spermatogonia differentiate into spermatocytes, which in turn undergo meiosis to eventually form mature sperm cells." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0000958 ! spermatogonium
 is_a: BTO:0002666 ! adult stem cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-29T16:40:05Z
 
 [Term]
@@ -48364,7 +48381,7 @@ id: BTO:0006350
 name: polyp
 def: "The sessile form of cnidarian (such as a coral or sea anemone) typically having a hollow cylindrical body closed and attached at one end and opening at the other by a central mouth surrounded by tentacles armed with nematocysts." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/polyp]
 is_a: BTO:0000284 ! organism form
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-29T16:50:41Z
 
 [Term]
@@ -48373,16 +48390,16 @@ name: glioma sphere-forming cell
 def: "Multipotent sphere-forming cells from human high grade glioma." [PMID:27541285]
 synonym: "GSC cell" RELATED []
 is_a: BTO:0000526 ! glioma cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-29T17:09:29Z
 
 [Term]
 id: BTO:0006352
 name: glomerular macrophage
-def: "Macrophage of the glomerulus." [curators:mgr]
+def: "Macrophage of the glomerulus." []
 is_a: BTO:0000801 ! macrophage
 relationship: part_of BTO:0000530 ! renal glomerulus
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-29T17:17:50Z
 
 [Term]
@@ -48392,7 +48409,7 @@ def: "Human B-lymphocyte cell line from blood of a peripheral vein." [Coriell_In
 synonym: "GM 12878 cell" RELATED []
 synonym: "GM12878 cell" RELATED []
 is_a: BTO:0002062 ! B-lymphoblastoid cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-29T17:26:24Z
 
 [Term]
@@ -48400,7 +48417,7 @@ id: BTO:0006354
 name: tracheal fluid
 relationship: develops_from BTO:0001388 ! trachea
 relationship: part_of BTO:0003606 ! airway fluid
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-29T17:32:01Z
 
 [Term]
@@ -48412,7 +48429,7 @@ synonym: "MILE SVEN1 cell" RELATED []
 synonym: "MS 1 cell" RELATED []
 synonym: "MS1 cell" RELATED []
 is_a: BTO:0000183 ! pancreatic cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-29T17:50:40Z
 
 [Term]
@@ -48420,7 +48437,7 @@ id: BTO:0006356
 name: renal oncocytoma cell
 def: "Renal oncocytoma is thought to arise from the intercalated cells of collecting ducts of the kidney." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0000680 ! kidney cancer cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-29T18:00:43Z
 
 [Term]
@@ -48429,7 +48446,7 @@ name: renal neoplasm cell
 def: "An abnormal growth of tissue in animals or plants. Neoplasms can be benign or malignant." [Medical_Dictionary:http\://medical-dictionary.thefreedictionary.com/]
 synonym: "renal tumor cell" RELATED []
 relationship: develops_from BTO:0000671 ! kidney
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-29T18:03:48Z
 
 [Term]
@@ -48440,7 +48457,7 @@ synonym: "TIG1 cell" RELATED []
 is_a: BTO:0000161 ! lung fibroblast cell line
 is_a: BTO:0001242 ! fetal cell line
 is_a: BTO:0001958 ! embryonic fibroblast cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-04-03T08:31:35Z
 
 [Term]
@@ -48449,7 +48466,7 @@ name: TEX cell
 def: "Stem cell-like AML cell line." [PMID:26624983]
 synonym: "TEX leukemia cell" RELATED []
 is_a: BTO:0001883 ! acute myeloid leukemia cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-04-03T08:40:52Z
 
 [Term]
@@ -48460,7 +48477,7 @@ synonym: "cSCC cell" RELATED []
 synonym: "cutaneous squamous cell carcinoma cell" RELATED []
 synonym: "squamous cell carcinoma of the skin" RELATED []
 is_a: BTO:0001289 ! squamous cell carcinoma cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-04-03T09:12:29Z
 
 [Term]
@@ -48470,7 +48487,7 @@ def: "Human ovarian carcinoma cell line." [PMID:27153830]
 synonym: "SK-OV-1 cell" RELATED []
 synonym: "SKOV1 cell" RELATED []
 is_a: BTO:0000811 ! ovary cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-04-03T09:31:09Z
 
 [Term]
@@ -48478,7 +48495,7 @@ id: BTO:0006362
 name: RMC cell
 def: "Rat kidney mesangial cell line. Rat mesangial cell at passage 8 were immortalized with pSV3-Neo and maintained in the presence of G418." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 is_a: BTO:0003581 ! renal glomerular cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-04-03T12:09:19Z
 
 [Term]
@@ -48486,7 +48503,7 @@ id: BTO:0006363
 name: rete mirabile
 def: "A small but dense network of blood vessels formed by the breaking up of a larger vessel into branches that usually reunite into one trunk and believed especially important as an oxygen-storing mechanism in aquatic mammals." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\://www.merriam-webster.com/dictionary/rete mirabile]
 is_a: BTO:0001102 ! blood vessel
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-04-03T12:46:44Z
 
 [Term]
@@ -48496,7 +48513,7 @@ def: "Human non-Hodgkin lymphoma cell line, established in 1992 from a patient i
 synonym: "Pfeiffer lymphoma cell" RELATED []
 is_a: BTO:0002904 ! non-Hodgkin lymphoma cell line
 is_a: BTO:0006365 ! diffuse large B-cell lymphoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-04-03T13:04:12Z
 
 [Term]
@@ -48504,7 +48521,7 @@ id: BTO:0006365
 name: diffuse large B-cell lymphoma cell line
 def: "Diffuse large B-cell lymphoma is a common type of non-Hodgkin lymphoma (NHL) accounting for about 2 in 5 of all cases. It is a cancer of the B-lymphocytes. Diffuse B-cell lymphoma can occur at any time between adolescence and old age. It is slightly more common in men than in women." [Cancerbackup.org:http\://www.cancerbackup.org.uk/Cancertype/Lymphomanon-Hodgkin/TypesofNHL/DiffuselargeB-cell]
 relationship: develops_from BTO:0001518 ! B-cell lymphoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-04-03T13:07:49Z
 
 [Term]
@@ -48513,7 +48530,7 @@ name: pericryptal myofibroblast
 is_a: BTO:0001946 ! myofibroblast
 is_a: BTO:0006367 ! pericryptal fibroblast
 relationship: part_of BTO:0000651 ! small intestine
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-04-03T13:19:52Z
 
 [Term]
@@ -48521,7 +48538,7 @@ id: BTO:0006367
 name: pericryptal fibroblast
 def: "Flattened fibroblasts forming a sheath around the intestinal glands of the colon." [Dorlands_Medical_Dictionary:MerckMedicus]
 is_a: BTO:0000452 ! fibroblast
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-04-03T13:27:29Z
 
 [Term]
@@ -48530,7 +48547,7 @@ name: PCI-51 cell
 def: "Human head and neck squamous carcinoma cell line." [PMID:26171609]
 synonym: "PCI51 cell" RELATED []
 is_a: BTO:0002709 ! head and neck squamous cell carcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-04-03T13:40:52Z
 
 [Term]
@@ -48538,7 +48555,7 @@ id: BTO:0006369
 name: PC-3ML cell
 def: "PC-3ML are highly metastatic sublines isolated from PC-3 cells." [PMID:26462052]
 relationship: develops_from BTO:0001061 ! PC-3 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-04-03T13:45:56Z
 
 [Term]
@@ -48546,7 +48563,7 @@ id: BTO:0006370
 name: opisthonephros
 def: "The opisthonephros is the functional adult kidney in lampreys (cyclostomes), most fishes, and amphibians. It is formed from the extended mesonephros along with tubules from the posterior nephric ridge. The functional embryonic kidney in anamniotes is the pronephros." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0000671 ! kidney
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-04-03T13:52:02Z
 
 [Term]
@@ -48555,7 +48572,7 @@ name: OBA-9 cell
 def: "A Simian virus-40 antigen-immortalized human gingival epithelial cell line." [PMID:25192897]
 synonym: "OBA9 cell" RELATED []
 is_a: BTO:0003578 ! gingival cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-04-04T11:00:30Z
 
 [Term]
@@ -48567,7 +48584,7 @@ synonym: "NPC-076 cell" RELATED []
 synonym: "NPC-TW076 cell" RELATED []
 synonym: "NPC076 cell" RELATED []
 is_a: BTO:0003960 ! nasopharyngeal carcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-04-04T11:14:34Z
 
 [Term]
@@ -48579,7 +48596,7 @@ synonym: "NPC-TW01 cell" RELATED []
 synonym: "NPC-TW039 cell" RELATED []
 synonym: "NPC039 cell" RELATED []
 is_a: BTO:0003960 ! nasopharyngeal carcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-04-04T11:21:28Z
 
 [Term]
@@ -48587,7 +48604,7 @@ id: BTO:0006374
 name: U87DND cell
 def: "A U87MG derived clone, defective in ceramide production de novo." [Universitat_de_Bologna;_Y._O._Vivanco:Chemical_tools_to_investigate_the_role_of_sphingolipids_in_disease]
 relationship: develops_from BTO:0002036 ! U-87MG cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-01-30T12:16:58Z
 
 [Term]
@@ -48595,7 +48612,7 @@ id: BTO:0006375
 name: 5TGM1 cell
 def: "Mouse multiple myeloma cell line." [PMID:29556454]
 is_a: BTO:0000727 ! multiple myeloma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-22T17:50:43Z
 
 [Term]
@@ -48603,7 +48620,7 @@ id: BTO:0006376
 name: 769-P cell
 def: "Renal cell adenocarcinoma cell line, established from a 63 years old caucasian female." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 is_a: BTO:0000383 ! renal cell carcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-22T17:53:51Z
 
 [Term]
@@ -48612,7 +48629,7 @@ name: AHH-1 cell
 def: "B-lymphoblast cell line." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 is_a: BTO:0002062 ! B-lymphoblastoid cell line
 relationship: develops_from BTO:0005255 ! RPMI-1788 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-22T18:00:25Z
 
 [Term]
@@ -48621,7 +48638,7 @@ name: AK-D cell
 def: "Felis catus fetal lung cell line." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 is_a: BTO:0000353 ! lung cell line
 is_a: BTO:0001242 ! fetal cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-22T18:02:32Z
 
 [Term]
@@ -48629,7 +48646,7 @@ id: BTO:0006379
 name: ALC cell
 synonym: "ameloblast-lineage cell" RELATED []
 relationship: develops_from BTO:0001663 ! ameloblast
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-22T18:13:27Z
 
 [Term]
@@ -48638,7 +48655,7 @@ name: BEL-7404-CP20 cell
 def: "BEL-7404 cell line, growing in 20microgramm per milliliter cisplatin for 24 months." [PMID:8660948]
 comment: Contaminated. Parental cell line has been shown to be a HeLa derivative.
 relationship: develops_from BTO:0005814 ! BEL-7404 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-22T18:22:33Z
 
 [Term]
@@ -48647,7 +48664,7 @@ name: bone lining cell
 def: "Bone lining cells cover inactive bone surfaces, particularly evident in the adult skeleton. BLC's are thinly extended over bone surfaces, have flat or slightly ovoid nuclei, connect to other BLC's via gap junctions, and send cell processes into surface canaliculi. BLC's can be induced to proliferate and differentiate into osteogenic cells and may represent a source of \"determined\" osteogenic precursors. BLC's and other cells of the endosteal tissues may be an integral part of the marrow stromal system and have important functions in hematopoiesis, perhaps by controlling the inductive microenvironment." [PMID:2694361]
 synonym: "BLC cell" RELATED []
 relationship: part_of BTO:0000140 ! bone
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-22T18:30:30Z
 
 [Term]
@@ -48655,7 +48672,7 @@ id: BTO:0006382
 name: CH12F3-2A cell
 def: "Mouse B cell lymphoma cell line." [Riken_BioResource_Center:http\\\://www2.brc.riken.jp/]
 relationship: develops_from BTO:0003990 ! CH12F3-2 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-22T18:36:05Z
 
 [Term]
@@ -48663,14 +48680,14 @@ id: BTO:0006383
 name: CHLA-90 cell
 def: "Human neuroblastoma cell line, established in 1990 from a 104months old child post chemotherapy." [Childrens_Oncology_Group:Texas_Tech_University_Health_Sciences_Center]
 is_a: BTO:0000932 ! neuroblastoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-22T18:41:40Z
 
 [Term]
 id: BTO:0006384
 name: synovial sarcoma cell line
 is_a: BTO:0000400 ! sarcoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-24T07:38:58Z
 
 [Term]
@@ -48680,7 +48697,7 @@ def: "Human synovial sarcoma cell line." [PMID:14556316]
 synonym: "CME 1 cell" RELATED []
 synonym: "CME1 cell" RELATED []
 is_a: BTO:0006384 ! synovial sarcoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-24T07:39:20Z
 
 [Term]
@@ -48690,14 +48707,14 @@ def: "Human synovial sarcoma cell line; established from a 25 years old caucasia
 synonym: "SW 982 cell" RELATED []
 synonym: "SW982 cell" RELATED []
 is_a: BTO:0006384 ! synovial sarcoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-24T07:43:11Z
 
 [Term]
 id: BTO:0006387
 name: craniofacial bone
 relationship: part_of BTO:0000282 ! head
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-24T07:59:40Z
 
 [Term]
@@ -48705,14 +48722,14 @@ id: BTO:0006388
 name: cuvierian tubule
 def: "Cuvierian tubules are clusters of fine tubes located at the base of the respiratory tree in some sea cucumbers in the genera Bohadschia, Holothuria and Pearsonothuria, all of which are included in the family Holothuriidae." [Wikipedia:The_Free_Encyclopedia]
 is_a: BTO:0001262 ! soft body part
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-24T08:32:11Z
 
 [Term]
 id: BTO:0006389
 name: enteric neuron
 is_a: BTO:0000938 ! neuron
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-24T08:43:56Z
 
 [Term]
@@ -48723,7 +48740,7 @@ synonym: "EOC 13.31 cell" RELATED []
 synonym: "EOC13 microglial cell line" RELATED []
 synonym: "EOC13.31 cell" RELATED []
 is_a: BTO:0003349 ! microglial cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-24T08:47:17Z
 
 [Term]
@@ -48731,7 +48748,7 @@ id: BTO:0006391
 name: ephyra
 def: "A free-swimming larva of a scyphozoan jellyfish formed by transverse fission of a scyphistoma and growing into a medusa." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:https\://www.merriam-webster.com/dictionary/ephyra]
 is_a: BTO:0000707 ! larva
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-24T10:36:37Z
 
 [Term]
@@ -48744,7 +48761,7 @@ synonym: "Fcwf4 cell" RELATED []
 synonym: "FCWF4 cell" RELATED []
 synonym: "Felis catus whole fetus-4 cell" RELATED []
 is_a: BTO:0001242 ! fetal cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-24T11:41:25Z
 
 [Term]
@@ -48754,7 +48771,7 @@ def: "cultures derived from parental 293-F cells that were re-cloned by limiting
 comment: Is a synonym of BTO:0005267, name: 293-F FreeStyle cell.
 synonym: "FreeStyle 293F-cell" RELATED []
 is_obsolete: true
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-26T11:48:54Z
 
 [Term]
@@ -48763,7 +48780,7 @@ name: GES-1 cell
 def: "Normal human gastric epithelial cell line." [PMID:  29991048]
 synonym: "GES1 cell" RELATED []
 is_a: BTO:0004493 ! gastric epithelium cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-26T12:04:48Z
 
 [Term]
@@ -48772,7 +48789,7 @@ name: HCC-1806 cell
 def: "Mammary gland cancer cell line, from a TNM stage IIB, grade 2, primary acantholytic squamous cell carcinoma." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 synonym: "HCC1806 cell" RELATED []
 is_a: BTO:0004086 ! mammary gland tumor cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-26T12:13:14Z
 
 [Term]
@@ -48780,7 +48797,7 @@ id: BTO:0006396
 name: HCE-T cell
 def: "An SV40-immortalized human corneal epithelial cell line." [RIKEN_BioResource_Center:http\://www2.brc.riken.jp/]
 is_a: BTO:0003221 ! corneal cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-26T12:16:08Z
 
 [Term]
@@ -48788,7 +48805,7 @@ id: BTO:0006397
 name: HCM cell
 def: "Primary Human Cardiac Myocytes isolated from the ventricles of the adult heart." [PromoCell:http\://www.promocell.com/]
 is_a: BTO:0003324 ! cardiomyocyte cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-26T12:21:41Z
 
 [Term]
@@ -48797,7 +48814,7 @@ name: MCF-10-2A cell
 def: "Nontumorigenic human mammary gland cell line from fibrocystic disease. MCA-10-2A was derived from adherent cells in the population. This line was established from the same tumor material as MCF 10A." [ATCC_American_Cell_Type_Culture_Collection:http\://www.lgcstandards-atcc.org/]
 synonym: "MCF 10-2A cell" RELATED []
 relationship: develops_from BTO:0003900 ! MCF-10F cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-26T12:28:10Z
 
 [Term]
@@ -48807,7 +48824,7 @@ def: "Human foetal lung fibroblast cell line; established from a 14 week old fem
 synonym: "HF19 cell" RELATED []
 is_a: BTO:0000161 ! lung fibroblast cell line
 is_a: BTO:0001242 ! fetal cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-27T07:54:06Z
 
 [Term]
@@ -48816,7 +48833,7 @@ name: HPMEC cell
 def: "Primary human pulmonary microvascular endothelial cells isolated from the lung from a single donor." [PromoCell:http\://www.promocell.com/]
 synonym: "primary human pulmonary microvascular endothelial cell" RELATED []
 is_a: BTO:0005738 ! lung microvascular endothelial cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-27T07:56:44Z
 
 [Term]
@@ -48827,7 +48844,7 @@ synonym: "IM cell" RELATED []
 synonym: "lung tissue macrophage" RELATED []
 synonym: "TM cell" RELATED []
 is_a: BTO:0000801 ! macrophage
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-27T08:43:23Z
 
 [Term]
@@ -48837,7 +48854,7 @@ def: "Porcine intestinal jejunum cell line; established from normal intestinal e
 synonym: "intestinal porcine epithelial cell line J2" RELATED []
 synonym: "IPECJ2 cell" RELATED []
 is_a: BTO:0000003 ! intestinal cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-27T08:50:04Z
 
 [Term]
@@ -48847,7 +48864,7 @@ def: "Porcine intestinal jejunum and ileum cell line; established from normal in
 synonym: "intestinal porcine epithelial cell line 1" RELATED []
 synonym: "IPEC1 cell" RELATED []
 is_a: BTO:0000003 ! intestinal cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-27T08:53:46Z
 
 [Term]
@@ -48859,7 +48876,7 @@ synonym: "JHU028 cell" RELATED []
 synonym: "O28 cell" RELATED []
 synonym: "SCC028 cell" RELATED []
 relationship: develops_from BTO:0000018 ! A-549 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-27T09:02:46Z
 
 [Term]
@@ -48868,7 +48885,7 @@ name: K-1 cell
 def: "Human thyroid carcinoma cell line; derived from a primary papillary thyroid carcinoma. It has been reported that K1 cells have their origin in the thyroid papillary carcinoma cell line GLAG-66." [SigmaAldrich:https\://www.sigmaaldrich.com/]
 synonym: "K1 cell" RELATED []
 relationship: develops_from BTO:0006406 ! GLAG-66 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-27T09:16:19Z
 
 [Term]
@@ -48877,7 +48894,7 @@ name: GLAG-66 cell
 def: "Primary thyroid papillary carcinoma cell line." [ECACC:European_Collection_of_Cell_Cultures]
 synonym: "GLAG66 cell" RELATED []
 is_a: BTO:0003210 ! papillary thyroid cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-27T09:18:45Z
 
 [Term]
@@ -48887,7 +48904,7 @@ def: "Murine osteosarcoma cell line; derived by intra-osseous injection of the K
 synonym: "K7M2 cell" RELATED []
 synonym: "K7M2 wt cell" RELATED []
 relationship: develops_from BTO:0006408 ! K7 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-27T09:25:50Z
 
 [Term]
@@ -48897,7 +48914,7 @@ def: "Mouse osteosarcoma K7 cell line." [PMID:17951400]
 synonym: "K 7 cell" RELATED []
 synonym: "K7 murine osteosarcoma cell" RELATED []
 is_a: BTO:0000407 ! osteosarcoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-27T09:30:00Z
 
 [Term]
@@ -48905,7 +48922,7 @@ id: BTO:0006409
 name: KB-CP20 cell
 def: "KB cells growing in 20microgram per milliliter cisplatin." [PMID:7710928]
 relationship: develops_from BTO:0000665 ! KB cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-27T09:33:40Z
 
 [Term]
@@ -48913,7 +48930,7 @@ id: BTO:0006410
 name: KB-CP10 cell
 def: "KB cells growing in 10microgram per milliliter cisplatin." [PMID:7710928]
 relationship: develops_from BTO:0000665 ! KB cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-27T09:38:22Z
 
 [Term]
@@ -48921,14 +48938,14 @@ id: BTO:0006411
 name: KB-CP5 cell
 def: "KB cells growing in 5microgram per milliliter cisplatin." [PMID:7710928]
 relationship: develops_from BTO:0000665 ! KB cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-27T09:38:38Z
 
 [Term]
 id: BTO:0006412
 name: myeolomonocytic leukemia cell line
 is_a: BTO:0000737 ! leukemia cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-27T09:50:21Z
 
 [Term]
@@ -48941,7 +48958,7 @@ synonym: "MV4-11 cell" RELATED []
 synonym: "MV4;11 cell" RELATED []
 synonym: "MV4II cell" RELATED []
 is_a: BTO:0006412 ! myeolomonocytic leukemia cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-27T09:50:44Z
 
 [Term]
@@ -48953,7 +48970,7 @@ synonym: "OCI-Ly 7 cell" RELATED []
 synonym: "OCI-LY-7 cell" RELATED []
 synonym: "OCILY7 cell" RELATED []
 is_a: BTO:0001518 ! B-cell lymphoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-27T10:01:33Z
 
 [Term]
@@ -48965,7 +48982,7 @@ synonym: "ovarian clear cell carcinoma cell line" RELATED []
 synonym: "ovarian clear-cell carcinoma cell line" RELATED []
 synonym: "ovary clear cell carcinoma cell line" RELATED []
 is_a: BTO:0001882 ! ovary adenocarcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-27T10:08:11Z
 
 [Term]
@@ -48973,7 +48990,7 @@ id: BTO:0006416
 name: Sertoli cell tumor cell line
 synonym: "Sertoli cell tumour cell line" RELATED []
 relationship: develops_from BTO:0001238 ! Sertoli cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-27T10:54:53Z
 
 [Term]
@@ -48982,7 +48999,7 @@ name: Sertoli cell tumor cell
 def: "A sex cord-gonadal stromal tumor of Sertoli cells. They can occur in the testis or ovary. They are very rare and generally peak between the ages of 35 and 50. They are typically well-differentiated, and may be misdiagnosed as seminomas as they often appear very similar." [Wikipedia:The_Free_Encyclopedia]
 synonym: "Sertoli cell tumour cell" RELATED []
 relationship: develops_from BTO:0001238 ! Sertoli cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-27T10:58:07Z
 
 [Term]
@@ -48991,7 +49008,7 @@ name: SCC-25/CP cell
 def: "Human head and neck squamous cell carcinoma cell line which is relatively stably resistant to CDDP after repeated exposure to escalating doses of the drug." [PMID:3539321]
 synonym: "SCC25/CP cell" RELATED []
 relationship: develops_from BTO:0003774 ! SCC-25 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-03-27T11:06:53Z
 
 [Term]
@@ -48999,7 +49016,7 @@ id: BTO:0006419
 name: FD105 cell
 def: "Human h-Tert immortalized AOA1 fibroblast cell line, derived from an individual with Ataxia with Oculomotor Apraxia type 1 (AOA1) and thus lacking aprataxin." [PMID:19303373, PMID:26204256]
 is_a: BTO:0000453 ! fibroblast cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-04-07T09:44:56Z
 
 [Term]
@@ -49007,7 +49024,7 @@ id: BTO:0006420
 name: MHM cell
 def: "Human osteosarcoma cell line from pelvis, established from primary patient samples at the Norwegian Radium Hospital." [PMID:17354236]
 is_a: BTO:0000407 ! osteosarcoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-04-07T10:53:07Z
 
 [Term]
@@ -49015,7 +49032,7 @@ id: BTO:0006421
 name: KPD cell
 def: "Human osteosarcoma cell line from femur, established from primary patient samples at the Norwegian Radium Hospital." [PMID:17354236]
 is_a: BTO:0000407 ! osteosarcoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-04-07T10:56:53Z
 
 [Term]
@@ -49027,7 +49044,7 @@ synonym: "HEK293 APPswe cell" RELATED []
 synonym: "HEK293-APPswe cell" RELATED []
 synonym: "HEK293/APPswe cell" RELATED []
 relationship: develops_from BTO:0000007 ! HEK-293 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-04-07T11:14:16Z
 
 [Term]
@@ -49041,7 +49058,7 @@ synonym: "HzAm1 cell" RELATED []
 synonym: "HZAM1 cell" RELATED []
 synonym: "HZBCIRLAM1 cell" RELATED []
 is_a: BTO:0000977 ! ovary cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-04-07T11:34:04Z
 
 [Term]
@@ -49055,7 +49072,7 @@ synonym: "HzAm2 cell" RELATED []
 synonym: "HZAM2 cell" RELATED []
 synonym: "HZBCIRLAM2 cell" RELATED []
 is_a: BTO:0000977 ! ovary cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-04-07T11:44:35Z
 
 [Term]
@@ -49069,7 +49086,7 @@ synonym: "HzAm3 cell" RELATED []
 synonym: "HZAM3 cell" RELATED []
 synonym: "HZBCIRLAM3 cell" RELATED []
 is_a: BTO:0000977 ! ovary cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-04-07T11:45:25Z
 
 [Term]
@@ -49079,7 +49096,7 @@ def: "Ovary cell line, derived from pupal ovaries of Heliothis virescens." [Arth
 synonym: "BCIRL-HVAM2 cell" RELATED []
 synonym: "BCIRL-HvAM2 cell" RELATED []
 is_a: BTO:0000977 ! ovary cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-04-07T11:46:44Z
 
 [Term]
@@ -49089,7 +49106,7 @@ def: "Ovary cell line, derived from pupal ovaries of Heliothis virescens." [Arth
 synonym: "BCIRL-HVAM1 cell" RELATED []
 synonym: "BCIRL-HvAM1 cell" RELATED []
 is_a: BTO:0000977 ! ovary cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-04-07T11:49:02Z
 
 [Term]
@@ -49098,7 +49115,7 @@ name: plant placenta
 def: "The part within the ovary of a flowering plant to which the ovules are attached." [TheFreeDictionary.com:http\\\://encyclopedia.thefreedictionary.com/]
 synonym: "placenta" RELATED []
 relationship: part_of BTO:0000750 ! plant ovary
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-11T17:33:27Z
 
 [Term]
@@ -49106,7 +49123,7 @@ id: BTO:0006429
 name: white adipocyte
 def: "White adipocytes are rounded cells that contain a single large fat droplet that occupies over 90% of the cell volume and the mitochondria and nucleus are squeezed into the remaining cell volume." [Functional_Atlas_of_the_Human_Fascial_System:2015]
 is_a: BTO:0000443 ! adipocyte
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-11T17:48:56Z
 
 [Term]
@@ -49114,7 +49131,7 @@ id: BTO:0006430
 name: brown adipocyte
 def: "Brown adipocytes include numerous mitochondria, which in part induce the darker color of this tissue compared to white adipose tissue." [Encyclopedia_of_Food_and_Health:2016]
 is_a: BTO:0000443 ! adipocyte
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-11T17:56:13Z
 
 [Term]
@@ -49123,7 +49140,7 @@ name: vagal lobe
 def: "An enlargement in the dorsal medulla oblongata associated with connections of the vagus nerve and, in some species, the glossopharyngeal nerve." [Dictionary_of_Ichthyology:http\\\://www.briancoad.com/Dictionary/Introduction.htm]
 synonym: "visceral lobe" RELATED []
 relationship: part_of BTO:0000041 ! medulla oblongata
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-24T11:19:33Z
 
 [Term]
@@ -49131,7 +49148,7 @@ id: BTO:0006432
 name: posterior tuberculum
 def: "The posterior tuberculum and the preglomerular complex are two dominant structures in the basal diencephalon of zebrafish, which also have no apparent counterparts in amniote tetrapods like birds and mammals. Yet, a large posterior tuberculum is present in jawless vertebrates (lampreys), cartilaginous fishes (sharks and manta rays), lungfish, and amphibians." [Zebrafish_UCL:http\://zebrafishucl.org/]
 relationship: part_of BTO:0000342 ! diencephalon
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-24T11:30:44Z
 
 [Term]
@@ -49140,7 +49157,7 @@ name: shuck
 def: "The outer covering of a nut or of an ear of corn." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\\\://www.m-w.com/cgi-bin/dictionary_book=Dictionary&va=shuck]
 is_a: BTO:0001227 ! seed coat
 relationship: part_of BTO:0001226 ! seed
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-24T11:39:03Z
 
 [Term]
@@ -49148,7 +49165,7 @@ id: BTO:0006434
 name: phylloid
 def: "A plant part functioning as or of similar origin to a leaf." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:http\\\://www.m-w.com/cgi-bin/dictionary_book=Dictionary&va=phylloid]
 relationship: part_of BTO:0001243 ! shoot
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-24T11:46:15Z
 
 [Term]
@@ -49158,7 +49175,7 @@ def: "Three human cancer cell lines (OC 314, OC 315, and OC 316) were newly esta
 synonym: "OC 314 cell" RELATED []
 synonym: "OC314 cell" RELATED []
 is_a: BTO:0003804 ! ovarian serous adenocarcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-24T11:57:16Z
 
 [Term]
@@ -49168,7 +49185,7 @@ def: "Three human cancer cell lines (OC 314, OC 315, and OC 316) were newly esta
 synonym: "OC 315 cell" RELATED []
 synonym: "OC315 cell" RELATED []
 is_a: BTO:0003804 ! ovarian serous adenocarcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-24T11:58:52Z
 
 [Term]
@@ -49178,7 +49195,7 @@ def: "Three human cancer cell lines (OC 314, OC 315, and OC 316) were newly esta
 synonym: "OC 316 cell" RELATED []
 synonym: "OC316 cell" RELATED []
 is_a: BTO:0003804 ! ovarian serous adenocarcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-24T11:59:50Z
 
 [Term]
@@ -49189,7 +49206,7 @@ synonym: "H-2030 cell" RELATED []
 synonym: "H2030 cell" RELATED []
 synonym: "NCIH2030 cell" RELATED []
 is_a: BTO:0004078 ! non-small cell lung adenocarcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-24T12:17:29Z
 
 [Term]
@@ -49198,7 +49215,7 @@ name: H-414 cell
 def: "Subline of HCT116 cell line which has intact DNA mismatch repair gene (hMLH1)." [Riken_BioResource_Center:http\\\://www2.brc.riken.jp/]
 synonym: "H414 cell" RELATED []
 relationship: develops_from BTO:0001109 ! HCT-116 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-24T12:27:02Z
 
 [Term]
@@ -49207,7 +49224,7 @@ name: HCC-1438 cell
 def: "Human lung large cell tumor cell line." [CreativeBioarray:www.creative-bioarray.com]
 synonym: "HCC1438 cell" RELATED []
 is_a: BTO:0002205 ! large cell lung cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-24T12:31:27Z
 
 [Term]
@@ -49216,7 +49233,7 @@ name: HCC-1500 cell
 def: "Mammary gland primary ductal carcinoma cell line." [ATCC_American_Cell_Type_Culture_Collection:http\\\://www.lgcstandards-atcc.org/]
 synonym: "HCC1500 cell" RELATED []
 is_a: BTO:0004086 ! mammary gland tumor cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-24T12:34:50Z
 
 [Term]
@@ -49225,7 +49242,7 @@ name: HCC-1833 cell
 def: "Human lung adenocarcinoma cell line." [CreativeBioarray:www.creative-bioarray.com]
 synonym: "HCC1833 cell" RELATED []
 is_a: BTO:0001911 ! lung adenocarcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-24T12:39:10Z
 
 [Term]
@@ -49233,7 +49250,7 @@ id: BTO:0006443
 name: culture condition:CD3+ cell
 def: "CD3 (cluster of differentiation 3) is a protein complex and T cell co-receptor that is involved in activating both the cytotoxic T cell (CD8+ naive T cells) and T helper cells (CD4+ naive T cells)." [Wikipedia:The_free_encyclopedia]
 is_a: BTO:0002008 ! culture condition:antigen-presenting cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-24T12:41:53Z
 
 [Term]
@@ -49241,7 +49258,7 @@ id: BTO:0006444
 name: Jeko-1 cell
 def: "Human peripheral blood mantle cell lymphoma cell line, established from the peripheral blood of a 78-year-old woman with B-cell non-Hodgkin lymphoma (B-NHL)." [ATCC_American_Cell_Type_Culture_Collection:http\\\://www.lgcstandards-atcc.org/, Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 is_a: BTO:0001518 ! B-cell lymphoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-24T16:08:13Z
 
 [Term]
@@ -49249,7 +49266,7 @@ id: BTO:0006445
 name: AF22 cell
 def: "Human neuroepithelial stem cell line. Induced pluripotent stem cells (iPSCs) generated from reprogrammed adult fibroblasts (ADF)." [Isenet_Biobanking:https\://www.isenetbiobanking.com/]
 is_a: BTO:0002891 ! neural stem cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-25T16:19:53Z
 
 [Term]
@@ -49257,7 +49274,7 @@ id: BTO:0006446
 name: CCD-1095Sk cell
 def: "Human normal skin fibroblast cell line, taken at biopsy from the left breast. The patient had infiltrating ductal carcinoma with associated Paget's disease of the nipple." [ATCC_American_Cell_Type_Culture_Collection:http\\\://www.lgcstandards-atcc.org/]
 is_a: BTO:0001619 ! skin fibroblast cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-25T16:52:59Z
 
 [Term]
@@ -49266,7 +49283,7 @@ name: EFM-19 cell
 def: "Human breast carcinoma cell line, established from the pleural effusion of a 50-year-old Caucasian woman with breast carcinoma (ductal type, histological grading II) in 1979." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 synonym: "EFM19 cell" RELATED []
 is_a: BTO:0000356 ! breast cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-25T16:58:14Z
 
 [Term]
@@ -49275,7 +49292,7 @@ name: F-180 cell
 def: "Human normal fibroblast cell line." [PMID:31537844]
 synonym: "F180 cell" RELATED []
 is_a: BTO:0000453 ! fibroblast cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-25T17:01:51Z
 
 [Term]
@@ -49284,7 +49301,7 @@ name: F-184 cell
 def: "Human normal fibroblast cell line." [PMID:31537844]
 synonym: "F184 cell" RELATED []
 is_a: BTO:0000453 ! fibroblast cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-25T17:06:56Z
 
 [Term]
@@ -49293,7 +49310,7 @@ name: FHCC-98 cell
 def: "Human hepatocellular carcinoma cell line." [PMID:15133854]
 synonym: "FHCC98 cell" RELATED []
 is_a: BTO:0000578 ! hepatoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-25T17:08:49Z
 
 [Term]
@@ -49301,7 +49318,7 @@ id: BTO:0006451
 name: peritoneal cancer cell
 def: "Cancer that forms in the peritoneum." [Cancer.gov_Dictionary:http\\\://www.nci.nih.gov/dictionary]
 relationship: develops_from BTO:0001472 ! peritoneum
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-25T17:24:30Z
 
 [Term]
@@ -49310,7 +49327,7 @@ name: HCCLM-9 cell
 def: "Human hepatocellular carcinoma cell line." [PMID:23904371]
 synonym: "HCCLM9 cell" RELATED []
 relationship: develops_from BTO:0004470 ! HCCLM-6 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-26T11:34:16Z
 
 [Term]
@@ -49319,7 +49336,7 @@ name: HEK-293S cell
 def: "Human embryonic kidney cell line expressing opsins." [PMID:12034766]
 synonym: "HEK293S cell" RELATED []
 relationship: develops_from BTO:0000007 ! HEK-293 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-26T11:44:29Z
 
 [Term]
@@ -49332,7 +49349,7 @@ synonym: "Hey-A8 cell" RELATED []
 synonym: "HEYA8 cell" RELATED []
 synonym: "HeyA8cell" RELATED []
 relationship: develops_from BTO:0002590 ! HEY cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-26T11:53:21Z
 
 [Term]
@@ -49342,7 +49359,7 @@ def: "Human hepatocyte cell line." [PMID:15780065]
 synonym: "HHL5 cell" RELATED []
 synonym: "Human Hepatocyte Line 5 cell" RELATED []
 is_a: BTO:0000224 ! liver cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-26T12:16:23Z
 
 [Term]
@@ -49354,7 +49371,7 @@ synonym: "H6C7 cell" RELATED []
 synonym: "HPDE6c7 cell" RELATED []
 synonym: "HPDEC cell" RELATED []
 is_a: BTO:0000183 ! pancreatic cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-26T12:25:40Z
 
 [Term]
@@ -49365,7 +49382,7 @@ synonym: "UMUC-1 cell" RELATED []
 synonym: "UMUC1 cell" RELATED []
 synonym: "University of Michigan-Urothelial Carcinoma-1 cell" RELATED []
 is_a: BTO:0002868 ! urinary bladder transitional cell carcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-26T12:51:50Z
 
 [Term]
@@ -49376,7 +49393,7 @@ synonym: "HepG2 VL17A cell" RELATED []
 synonym: "VL-17A cell" RELATED []
 synonym: "VL17A cell" RELATED []
 relationship: develops_from BTO:0000599 ! Hep-G2 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-26T12:55:55Z
 
 [Term]
@@ -49388,7 +49405,7 @@ synonym: "KMS-12BM cell" RELATED []
 synonym: "KMS12-BM cell" RELATED []
 synonym: "KMS12BM" RELATED []
 is_a: BTO:0000727 ! multiple myeloma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-26T18:27:36Z
 
 [Term]
@@ -49400,7 +49417,7 @@ synonym: "KMS-12PE cell" RELATED []
 synonym: "KMS12-PE cell" RELATED []
 synonym: "KMS12PE cell" RELATED []
 is_a: BTO:0000727 ! multiple myeloma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-26T18:32:53Z
 
 [Term]
@@ -49409,7 +49426,7 @@ name: KMS-26 cell
 def: "Human myeloma cell line." [JCRB_Japanese_Collection_of_Research_Bioresources:http\\\://cellbank.nibio.go.jp/]
 synonym: "KMS26 cell" RELATED []
 is_a: BTO:0000899 ! myeloma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-26T18:37:27Z
 
 [Term]
@@ -49424,7 +49441,7 @@ synonym: "SuDHL 4 cell" RELATED []
 synonym: "SUDHL-4 cell" RELATED []
 synonym: "SUDHL4 cell" RELATED []
 is_a: BTO:0006365 ! diffuse large B-cell lymphoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-26T18:47:30Z
 
 [Term]
@@ -49439,7 +49456,7 @@ synonym: "SuDHL 2 cell" RELATED []
 synonym: "SUDHL-2 cell" RELATED []
 synonym: "SUDHL2 cell" RELATED []
 is_a: BTO:0001518 ! B-cell lymphoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-26T18:51:22Z
 
 [Term]
@@ -49449,7 +49466,7 @@ def: "Muscle invasive bladder cancer (MIBC) is a cancer that spreads into the de
 synonym: "MIBC cell" RELATED []
 synonym: "muscle-invasive bladder cancer cell" RELATED []
 is_a: BTO:0000362 ! urinary bladder cancer cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-26T19:11:14Z
 
 [Term]
@@ -49457,7 +49474,7 @@ id: BTO:0006465
 name: intestinal stem cell
 def: "Intestinal stem cells are multipotent adult stem cells, which in mammals reside in the base of the crypts of the adult intestine. Intestinal stem cells continuously self-renew by dividing and differentiate into the specialised cells of the intestinal epithelium, which renews throughout life." [NatureResearch:https\://www.nature.com/subjects/intestinal-stem-cells]
 is_a: BTO:0002666 ! adult stem cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-09-26T19:19:55Z
 
 [Term]
@@ -49467,7 +49484,7 @@ def: "Human lung adenocarcinoma cell line, established from the pleural effusion
 synonym: "LC-2-Ad cell" RELATED []
 synonym: "LC2/Ad cell" RELATED []
 is_a: BTO:0001911 ! lung adenocarcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-10-08T16:52:26Z
 
 [Term]
@@ -49479,14 +49496,14 @@ synonym: "AblLNCaP cell" RELATED []
 synonym: "androgen-independent LNCaP cell" RELATED []
 synonym: "LNCaPAbl cell" RELATED []
 relationship: develops_from BTO:0001321 ! LNCaP cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-10-08T17:00:52Z
 
 [Term]
 id: BTO:0006468
 name: peritoneal cell line
 relationship: develops_from BTO:0001472 ! peritoneum
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-10-08T17:22:22Z
 
 [Term]
@@ -49495,7 +49512,7 @@ name: LP-9 cell
 def: "Normal human peritoneal mesothelial cell line." [PMID:32681052]
 synonym: "LP9 cell" RELATED []
 is_a: BTO:0006468 ! peritoneal cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-10-08T17:23:37Z
 
 [Term]
@@ -49505,7 +49522,7 @@ def: "Cell line generated from MDA-MB-231 cells co-transfected with reporter pla
 synonym: "MDA-MB-231 met2 cell" RELATED []
 synonym: "MDA-MB-231met2 cell" RELATED []
 relationship: develops_from BTO:0000815 ! MDA-MB-231 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-10-08T17:46:17Z
 
 [Term]
@@ -49514,7 +49531,7 @@ name: MIHA cell
 def: "Normal immortalized human hepatocyte cell line." [PMID:29303507]
 synonym: "IHH cell" RELATED []
 is_a: BTO:0000224 ! liver cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-10-09T15:13:28Z
 
 [Term]
@@ -49524,7 +49541,7 @@ def: "Human fibroblast cell line." [PMID:27618981]
 synonym: "GM-1617 cell" RELATED []
 synonym: "GMO1617 cell" RELATED []
 is_a: BTO:0000453 ! fibroblast cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-10-09T16:19:33Z
 
 [Term]
@@ -49533,7 +49550,7 @@ name: brain-corpora cardiaca-corpora allata complex
 def: "The brain-corpora cardiaca-corpora allata complex of insects is the physiological equivalent of the brain-hypophysis axis of vertebrates." [PMID: 9522462]
 synonym: "corpora cardiaca-corpora allata complex" RELATED []
 relationship: part_of BTO:0000142 ! brain
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-10-09T16:27:34Z
 
 [Term]
@@ -49541,7 +49558,7 @@ id: BTO:0006474
 name: rhizoid
 def: "A slender rootlike filament that grows from an alga, a fungus, or the gametophyte of a moss, liverwort, or fern, used for attachment and nourishment." [Dictionary:http\\\://www.thefreedictionary.com/]
 is_a: BTO:0001188 ! root
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-10-09T16:32:11Z
 
 [Term]
@@ -49549,7 +49566,7 @@ id: BTO:0006475
 name: Sai1 cell
 def: "Neural embryonic stem cell line isolated from embryonic hindbrain, Carnegie stage 15." [PMID:28041877]
 is_a: BTO:0001581 ! embryonic stem cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-10-09T16:36:14Z
 
 [Term]
@@ -49557,7 +49574,7 @@ id: BTO:0006476
 name: synencephalon
 def: "Multi-tissue structure that is located between the dorsal diencephalon and the mesencephalon and contains the caudal commissure." [Neuroanatomy_of_the_Zebrafish_Brain:<new dbxref>]
 relationship: part_of BTO:0000142 ! brain
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2020-10-09T16:42:37Z
 
 [Term]
@@ -49565,7 +49582,7 @@ id: BTO:0006477
 name: T37i cell
 def: "Mouse brown adipocyte cell line; derived from a hibernoma (malignant brown fat tumor) of a transgenic mouse carrying a hybrid gene composed of the human MR proximal promoter linked to the SV40 large T antigen." [Merck_Millipore:https\://www.merckmillipore.com/DE/de/product/T37i-Mouse-Brown-Adipocyte-Cell-Line\,MM_NF-SCC250]
 is_a: BTO:0003452 ! adipocyte cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-04T09:33:11Z
 
 [Term]
@@ -49573,7 +49590,7 @@ id: BTO:0006478
 name: Bm7Brm cell
 def: "Lung cancer cells with progressive migration ability." [PMID:28537886]
 relationship: develops_from BTO:0006333 ! BM7 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-02-03T10:35:42Z
 
 [Term]
@@ -49584,7 +49601,7 @@ synonym: "HEP-3B C1 cell" RELATED []
 synonym: "Hep3B-C1 cell" RELATED []
 synonym: "Hep3Bc1 cell" RELATED []
 relationship: develops_from BTO:0000972 ! HEP-3B cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-04T09:45:33Z
 
 [Term]
@@ -49594,7 +49611,7 @@ def: "B cell lymphoma cell line; established in 1982 from the cerebrospinal flui
 synonym: "NUDUL-1 cell" RELATED []
 synonym: "NUDUL1 cell" RELATED []
 is_a: BTO:0001518 ! B-cell lymphoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-04T10:07:23Z
 
 [Term]
@@ -49607,7 +49624,7 @@ synonym: "lateral hypothalamic region" RELATED []
 synonym: "LH" RELATED []
 synonym: "LHA" RELATED []
 relationship: part_of BTO:0000614 ! hypothalamus
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-04T10:11:32Z
 
 [Term]
@@ -49616,7 +49633,7 @@ name: SNU-719 cell
 def: "Human gastric cancer cell line." [PMID:15016554]
 synonym: "SNU719 cell" RELATED []
 is_a: BTO:0000787 ! gastric cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-04T18:13:55Z
 
 [Term]
@@ -49628,7 +49645,7 @@ synonym: "GL261 cell" RELATED []
 synonym: "Glioma 261 cell" RELATED []
 synonym: "Glioma-261 cell" RELATED []
 is_a: BTO:0001530 ! glioblastoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-04T18:22:17Z
 
 [Term]
@@ -49640,7 +49657,7 @@ synonym: "HMT-3522/wt cell" RELATED []
 synonym: "HMT-3522S1 cell" RELATED []
 synonym: "HMT3522S1 cell" RELATED []
 relationship: develops_from BTO:0003884 ! HMT-3522 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-04T18:28:46Z
 
 [Term]
@@ -49652,7 +49669,7 @@ synonym: "PATU-8902 cell" RELATED []
 synonym: "PaTu-8902 cell" RELATED []
 synonym: "PATU8902 cell" RELATED []
 is_a: BTO:0001521 ! pancreatic adenocarcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-04T18:32:41Z
 
 [Term]
@@ -49660,7 +49677,7 @@ id: BTO:0006486
 name: myxofibrosarcoma cell
 def: "A malignant fibrous histiocytoma with a predominance of myxoid areas that resemble primitive mesenchymal tissue." [Medical_Dictionary:http\\\://medical-dictionary.thefreedictionary.com/]
 is_a: BTO:0003431 ! dermatofibroma cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-04T18:38:13Z
 
 [Term]
@@ -49668,7 +49685,7 @@ id: BTO:0006487
 name: aerodigestive tract
 def: "The mixed airway and gastrointestinal tract that includes the oral cavity, pharynx, paranasal sinuses, sinonasal tract, larynx, pyriform sinus, pharynx, and upper oesophagus." [Medical_Dictionary:http\\\://medical-dictionary.thefreedictionary.com/]
 is_a: BTO:0001491 ! viscus
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-04T18:47:12Z
 
 [Term]
@@ -49676,7 +49693,7 @@ id: BTO:0006488
 name: steroidogenic cell
 def: "Cell of, relating to, or involved in steroidogenesis." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:https\://www.merriam-webster.com/medical/steroidogenic]
 is_a: BTO:0002322 ! cell property
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-04T18:48:39Z
 
 [Term]
@@ -49684,7 +49701,7 @@ id: BTO:0006489
 name: brood pouch
 def: "A sac or cavity of the body of an animal where the eggs or embryos are received and undergo a part of their development." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:https\://www.merriam-webster.com/dictionary/brood_20pouch]
 relationship: part_of BTO:0001493 ! trunk
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-04T18:58:52Z
 
 [Term]
@@ -49693,7 +49710,7 @@ name: GT-38 cell
 def: "Human EBV-associated gastric cancer cell line." [PMID:32056716]
 synonym: "GT38 cell" RELATED []
 is_a: BTO:0000787 ! gastric cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-12T10:19:00Z
 
 [Term]
@@ -49702,7 +49719,7 @@ name: GT-39 cell
 def: "Human EBV-associated gastric cancer cell line." [PMID:32056716]
 synonym: "GT39 cell" RELATED []
 is_a: BTO:0000787 ! gastric cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-12T10:22:18Z
 
 [Term]
@@ -49712,7 +49729,7 @@ def: "The upper (distal), usually smaller, of the pair of flower bracts enclosin
 synonym: "pale" BROAD []
 synonym: "palet" RELATED []
 relationship: part_of BTO:0002119 ! spikelet
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-12T10:31:24Z
 
 [Term]
@@ -49721,7 +49738,7 @@ name: myxoliposarcoma cell
 def: "A liposarcoma characterized by the presence of round non-lipogenic primitive mesenchymal cells and small signet ring lipoblasts within a myxoid stoma with a branching vascular pattern. This category includes hypercellular lesions with round cell morphology, formerly known as round cell liposarcoma." [NIH_National_Cancer_Institute:NCIthesaurus]
 synonym: "myxoid liposarcoma cell" RELATED []
 is_a: BTO:0003745 ! liposarcoma cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-12T10:52:42Z
 
 [Term]
@@ -49730,7 +49747,7 @@ name: fibromyxosarcoma cell
 def: "A sarcoma containing fibrous and myxoid tissue." [Medical_Dictionary:http\\\://medical-dictionary.thefreedictionary.com/]
 synonym: "fibromyxoid sarcoma cell" RELATED []
 is_a: BTO:0000459 ! fibrosarcoma cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-12T11:00:25Z
 
 [Term]
@@ -49738,7 +49755,7 @@ id: BTO:0006495
 name: spathe
 def: "A sheathing bract or pair of bracts partly enclosing an inflorescence and especially a spadix on the same axis." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:https\://www.merriam-webster.com/dictionary/spathe]
 relationship: part_of BTO:0006496 ! inflorescence bract
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-12T11:05:59Z
 
 [Term]
@@ -49746,7 +49763,7 @@ id: BTO:0006496
 name: inflorescence bract
 def: "A bract subtending a branch of the inflorescence or borne on the inflorescence axis below any branch  or flower." [Plant_Ontology:https\://raw.githubusercontent.com/Planteome/plant-ontology/master/po.obo]
 is_a: BTO:0002222 ! bract
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-12T11:08:59Z
 
 [Term]
@@ -49754,7 +49771,7 @@ id: BTO:0006497
 name: NASS cell
 def: "MYCN single copy neuroblastoma cell line." [PMID:27906629]
 is_a: BTO:0000932 ! neuroblastoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-13T19:54:19Z
 
 [Term]
@@ -49762,14 +49779,14 @@ id: BTO:0006498
 name: FISK cell
 def: "MYCN single copy neuroblastoma cell line." [PMID:27906629]
 is_a: BTO:0000932 ! neuroblastoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-13T19:55:03Z
 
 [Term]
 id: BTO:0006499
 name: spermatocyte cell line
 relationship: develops_from BTO:0001275 ! spermatocyte
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-13T20:00:39Z
 
 [Term]
@@ -49782,7 +49799,7 @@ synonym: "GC-2spd(ts) cell" RELATED []
 synonym: "GC2 cell" RELATED []
 synonym: "GC2spd(ts) cell" RELATED []
 is_a: BTO:0006499 ! spermatocyte cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-13T20:01:00Z
 
 [Term]
@@ -49791,7 +49808,7 @@ name: natural killer T cell
 def: "A heterogeneous group of T cells that share properties of both T cells and natural killer cells." [Wikipedia:The_free_encyclopedia]
 synonym: "NKT cell" RELATED []
 is_a: BTO:0000782 ! T-lymphocyte
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-13T20:12:25Z
 
 [Term]
@@ -49799,7 +49816,7 @@ id: BTO:0006502
 name: Jar-GnT4a cell
 def: "Human choriocarcinoma cell line with GnT-IVa overexpression." [PMID:28534963]
 relationship: develops_from BTO:0001585 ! JAR cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-13T20:17:13Z
 
 [Term]
@@ -49807,7 +49824,7 @@ id: BTO:0006503
 name: CGL-2 cell
 def: "A fusion hybrid of the HeLa adenocarcinoma cell line and normal human fibroblasts. This cell line derived from a hybrid of the HeLa variant, D98/AH2, and a normal human fibroblast strain, GM77." [PMID:15471901]
 relationship: develops_from BTO:0000567 ! HeLa cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-13T20:22:16Z
 
 [Term]
@@ -49815,7 +49832,7 @@ id: BTO:0006504
 name: oculomotor nucleus
 def: "The fibers of the oculomotor nerve arise from a nucleus in the midbrain, which lies in the gray substance of the floor of the cerebral aqueduct and extends in front of the aqueduct for a short distance into the floor of the third ventricle." [Wikipedia:The_free_encyclopedia]
 relationship: part_of BTO:0000138 ! midbrain
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-18T11:04:03Z
 
 [Term]
@@ -49824,7 +49841,7 @@ name: Edinger-Westphal nucleus
 def: "The parasympathetic pre-ganglionic nucleus that innervates the iris sphincter muscle and the ciliary muscle. Alternatively, the term is often used to refer to the adjacent population of non-preganglionic neurons that do not project to the ciliary ganglion, but rather project to the spinal cord, dorsal raphe nucleus, lateral septal nuclei, lateral hypothalamic area and the central nucleus of the amygdala, among other regions." [Wikipedia:The_free_encyclopedia]
 synonym: "accessory oculomotor nucleus" RELATED []
 relationship: part_of BTO:0000138 ! midbrain
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-18T11:05:43Z
 
 [Term]
@@ -49832,7 +49849,7 @@ id: BTO:0006506
 name: CL1-5 Fut8-KD cell
 def: "CL1-5 cell line with Fucosyltransferase 8, Fut8, knocked down." [PMID:28678517]
 relationship: develops_from BTO:0002876 ! CL1-5 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-18T11:22:00Z
 
 [Term]
@@ -49844,7 +49861,7 @@ synonym: "Lec8 cell" RELATED []
 synonym: "Pro-5WgaRVIII3D cell" RELATED []
 relationship: develops_from BTO:0000246 ! CHO cell
 relationship: develops_from BTO:0002176 ! Pro-5 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-19T09:41:46Z
 
 [Term]
@@ -49853,7 +49870,7 @@ name: TPC-1 cell
 def: "Human papillary thyroid carcinoma cell line." [Sigma_Aldrich:http\\\://www.sigmaaldrich.com/]
 synonym: "TPC1 cell" RELATED []
 is_a: BTO:0003210 ! papillary thyroid cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-19T09:57:08Z
 
 [Term]
@@ -49862,7 +49879,7 @@ name: Hca-P cell
 def: "The Hca-F and Hca-P cell lines are subclones derived from the same parent cells of mouse hepatocarcinoma ascitic cells. In tumor-bearing mice, Hca-F cells have an approximate 70% lymph node metastasis rate and Hca-P cells have an approximate 30% lymph node metastasis." [PMID:29783989]
 synonym: "HcaP cell" RELATED []
 is_a: BTO:0000578 ! hepatoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-19T10:02:16Z
 
 [Term]
@@ -49870,7 +49887,7 @@ id: BTO:0006510
 name: MOSEC cell
 def: "Mouse ovarian surface epithelial cell line." [PMID:28423672]
 is_a: BTO:0004482 ! ovarian surface epithelial cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-19T10:16:22Z
 
 [Term]
@@ -49881,7 +49898,7 @@ synonym: "PMF-ko14 cell" RELATED []
 synonym: "PMFko14 cell" RELATED []
 synonym: "PMFKO14 cell" RELATED []
 is_a: BTO:0000797 ! colonic cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-19T10:55:15Z
 
 [Term]
@@ -49893,7 +49910,7 @@ synonym: "SPC-A1 cell" RELATED []
 synonym: "SPCA1 cell" RELATED []
 is_a: BTO:0001911 ! lung adenocarcinoma cell line
 relationship: develops_from BTO:0000567 ! HeLa cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-19T11:06:00Z
 
 [Term]
@@ -49904,7 +49921,7 @@ synonym: "HEK 293/AT1 cell" RELATED []
 synonym: "HEK-293/AT1 cell" RELATED []
 synonym: "HEK293-AT1 cell" RELATED []
 relationship: develops_from BTO:0000007 ! HEK-293 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-19T11:37:54Z
 
 [Term]
@@ -49912,7 +49929,7 @@ id: BTO:0006514
 name: foreleg
 def: "A front leg." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:https\://www.merriam-webster.com/dictionary/foreleg]
 is_a: BTO:0000721 ! leg
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-21T17:34:32Z
 
 [Term]
@@ -49921,7 +49938,7 @@ name: hindleg
 def: "The posterior leg of a quadruped." [From_Merriam-Webster's_Online_Dictionary_at_www.Merriam-Webster.com:https\://www.merriam-webster.com/dictionary/hind leg]
 synonym: "hind leg" RELATED []
 is_a: BTO:0000721 ! leg
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-21T17:36:28Z
 
 [Term]
@@ -49931,7 +49948,7 @@ def: "In arthropods, the maxillae are paired structures present on the head as m
 synonym: "maxilla" RELATED []
 relationship: develops_from BTO:0006517 ! maxillary palp
 relationship: part_of BTO:0001090 ! mouth
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-21T17:49:28Z
 
 [Term]
@@ -49939,7 +49956,7 @@ id: BTO:0006517
 name: maxillary palp
 def: "Embryologically, the maxillae are derived from the 4th and 5th segment of the head and the maxillary palps." [Wikipedia:The_free_encyclopedia]
 relationship: part_of BTO:0001090 ! mouth
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-21T17:50:30Z
 
 [Term]
@@ -49948,7 +49965,7 @@ name: storage parenchyma
 def: "Storage parenchyma is specialized as large water storage tissue in many succulent and xerophytic plants with greatly expanded vacuole. The cells are chlorophyll-free and thin-walled. In potatoes tuber and grain for example, the parenchyma acts as a special storage tissue to store food material." [Plant_Tissues_And_Cells:https\://eima86.tripod.com/id4.html]
 synonym: "storage parenchyma cell" RELATED []
 is_a: BTO:0000999 ! plant parenchyma
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-21T17:54:10Z
 
 [Term]
@@ -49959,7 +49976,7 @@ synonym: "mezontle" RELATED []
 synonym: "piña" RELATED []
 is_a: BTO:0003841 ! plant organ culture
 relationship: part_of BTO:0001461 ! whole plant
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-03-21T18:17:41Z
 
 [Term]
@@ -49967,7 +49984,7 @@ id: BTO:0006520
 name: SKM-1 cell
 def: "Human acute myeloid leukemia cell line, established from the peripheral blood of a 76-year-old man with acute monoblastic leukemia in 1989 following myelodysplastic syndromes." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 is_a: BTO:0001883 ! acute myeloid leukemia cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-09-11T17:37:52Z
 
 [Term]
@@ -49977,7 +49994,7 @@ def: "Human plasma cell leukemia cell line,\nestablished in 1981 from the bone m
 synonym: "SKMM-1 cell" RELATED []
 synonym: "SKMM1 cell" RELATED []
 is_a: BTO:0000456 ! plasmacytoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-09-11T17:41:14Z
 
 [Term]
@@ -49986,7 +50003,7 @@ name: trochophore
 def: "A trochophore is a type of free-swimming planktonic marine larva with several bands of cilia." [Wikipedia:The_free_encyclopedia]
 synonym: "trocophore" RELATED []
 is_a: BTO:0000707 ! larva
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-09-11T17:47:06Z
 
 [Term]
@@ -49995,7 +50012,7 @@ name: AII amacrine cell
 def: "AII amacrine cells are a subtype of amacrine cells present in the retina of mammals." [Wikipedia:The_free_encyclopedia]
 synonym: "Aii amacrine cell" RELATED []
 is_a: BTO:0004044 ! amacrine cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-09-11T18:03:55Z
 
 [Term]
@@ -50004,7 +50021,7 @@ name: NCI-H1522 cell
 def: "Human small cell lung cancer cell line. Stage E cancer." [ATCC_American_Cell_Type_Culture_Collection:http\\\://www.lgcstandards-atcc.org/]
 synonym: "H1522 cell" RELATED []
 is_a: BTO:0002206 ! small cell lung cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-09-12T13:02:01Z
 
 [Term]
@@ -50013,7 +50030,7 @@ name: NCI-H1836 cell
 def: "Human small cell lung cancer cell line. Stage L cancer." [ATCC_American_Cell_Type_Culture_Collection:http\\\://www.lgcstandards-atcc.org/]
 synonym: "H1836 cell" RELATED []
 is_a: BTO:0002206 ! small cell lung cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-09-12T13:05:10Z
 
 [Term]
@@ -50022,7 +50039,7 @@ name: NCI-H2141 cell
 def: "Human small cell lung cancer cell line. Stage E cancer. Cell type lymphoblast." [ATCC_American_Cell_Type_Culture_Collection:http\\\://www.lgcstandards-atcc.org/]
 synonym: "H2141 cell" RELATED []
 is_a: BTO:0002206 ! small cell lung cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-09-12T13:08:15Z
 
 [Term]
@@ -50030,7 +50047,7 @@ id: BTO:0006527
 name: BPLER cell
 def: "Highly malignant human triple-negative breast cancer cell line." [PMID:30349315]
 is_a: BTO:0000356 ! breast cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-09-12T13:26:01Z
 
 [Term]
@@ -50038,7 +50055,7 @@ id: BTO:0006528
 name: HMLER cell
 def: "Less malignant isogenic human triple-negative breast cancer cell line." [PMID:30349315]
 is_a: BTO:0000356 ! breast cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-09-12T13:27:29Z
 
 [Term]
@@ -50046,7 +50063,7 @@ id: BTO:0006529
 name: HCC-33 cell
 def: "Human small cell lung carcinoma cell line, established from the pleural effusion of a 52-year-old man with small cell lung carcinoma." [Deutsche_Sammlung_von_Mikroorganismen_und_Zellkulturen_GmbH:DSMZ]
 is_a: BTO:0002206 ! small cell lung cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-09-12T13:33:33Z
 
 [Term]
@@ -50054,7 +50071,7 @@ id: BTO:0006530
 name: 6DT1 cell
 def: "6DT1 mouse\nmammary carcinoma cell line, derived from an MMTV-c-Myc\ntransgenic mouse model." [PMID:25368990]
 is_a: BTO:0000356 ! breast cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-09-29T08:50:13Z
 
 [Term]
@@ -50067,7 +50084,7 @@ synonym: "EBV-LCL 721 cell" RELATED []
 synonym: "LCL 721 cell" RELATED []
 synonym: "LCL721 cell" RELATED []
 is_a: BTO:0002062 ! B-lymphoblastoid cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-09-29T09:05:49Z
 
 [Term]
@@ -50075,7 +50092,7 @@ id: BTO:0006532
 name: 80S14 cell
 def: "A p21 clone of HCT116 derived by homologous recombination." [PMID:10781590]
 relationship: develops_from BTO:0001109 ! HCT-116 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-09-29T09:57:23Z
 
 [Term]
@@ -50084,7 +50101,7 @@ name: branchial crown
 def: "A structure surrounding the terminal mouth composed of ciliated, bipinnate filaments functioning in suspension filter feeding and respiration. (Annelida, Polychaeta)" [Dictionary_of_Invertebrate_Zoology:http\\\://species-id.net/zooterms/]
 synonym: "tentacular crown" RELATED []
 is_a: BTO:0001262 ! soft body part
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-09-29T10:01:08Z
 
 [Term]
@@ -50093,14 +50110,14 @@ name: cerebral nucleus
 def: "The term cerebral nuclei refers to one of three components of the cerebrum. It is a composite structure of the endbrain defined on the basis of origin from the ventricular ridge of the embryonic Encephalon. It consists of the extended striatum and the extended pallidum." [Braininfo:http\://braininfo.rprc.washington.edu/centraldirectory.aspx?ID=2677]
 synonym: "cerebral nuclei" RELATED []
 relationship: develops_from BTO:0004726 ! embryonic brain
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-09-29T10:59:22Z
 
 [Term]
 id: BTO:0006535
 name: gill cell line
 relationship: develops_from BTO:0000518 ! gill
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-09-29T11:21:33Z
 
 [Term]
@@ -50111,7 +50128,7 @@ synonym: "FG cell" RELATED []
 synonym: "FG9307 cell" RELATED []
 synonym: "Flounder Gill-9307 cell" RELATED []
 is_a: BTO:0006535 ! gill cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-09-29T11:21:57Z
 
 [Term]
@@ -50119,7 +50136,7 @@ id: BTO:0006537
 name: GSC11 cell
 def: "Human glioblastoma stem cell line, derived from human primary glioblastoma tissues." [PMID:23132831]
 is_a: BTO:0006001 ! GSC cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-09-29T14:04:45Z
 
 [Term]
@@ -50127,7 +50144,7 @@ id: BTO:0006538
 name: GSC23 cell
 def: "Human glioblastoma stem cell line, derived from human primary glioblastoma tissues." [PMID:23132831]
 is_a: BTO:0006001 ! GSC cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-09-29T14:07:33Z
 
 [Term]
@@ -50137,7 +50154,7 @@ def: "Human non-small-cell lung cancer cell line." [PMID:15492241]
 synonym: "H-3255 cell" RELATED []
 synonym: "H3255 cell" RELATED []
 is_a: BTO:0002206 ! small cell lung cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-09-29T14:24:39Z
 
 [Term]
@@ -50147,7 +50164,7 @@ def: "Human foetal lung cell line, SV40 transformed. Derived from the parental c
 synonym: "MRC-5 SV2 cell" RELATED []
 synonym: "MRC5-SV12 cell" RELATED []
 relationship: develops_from BTO:0001590 ! MRC-5 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-09-29T14:33:03Z
 
 [Term]
@@ -50157,7 +50174,7 @@ def: "Human small-cell lung cancer cell line." [PMID:2414316]
 synonym: "H-60 cell" RELATED []
 synonym: "H60 cell" RELATED []
 is_a: BTO:0002206 ! small cell lung cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-09-29T14:41:34Z
 
 [Term]
@@ -50166,7 +50183,7 @@ name: NEC-8 cell
 def: "Human testicular germ cell tumor cell line." [JCRB_Japanese_Collection_of_Research_Bioresources:http\\\://cellbank.nibio.go.jp/]
 synonym: "NEC8 cell" RELATED []
 is_a: BTO:0004229 ! testicular cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-09-29T14:47:22Z
 
 [Term]
@@ -50175,7 +50192,7 @@ name: HF-2303 cell
 def: "Human glioblastoma cell line." [PMID:27564115]
 synonym: "HF2303 cell" RELATED []
 is_a: BTO:0001530 ! glioblastoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-10-09T13:19:16Z
 
 [Term]
@@ -50184,7 +50201,7 @@ name: IN-859 cell
 def: "Human glioblastoma cell line." [PMID:27564115]
 synonym: "IN859 cell" RELATED []
 is_a: BTO:0001530 ! glioblastoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-10-09T13:20:48Z
 
 [Term]
@@ -50193,7 +50210,7 @@ name: MGG-8 cell
 def: "Human glioblastoma cell line." [PMID:27564115]
 synonym: "MGG8 cell" RELATED []
 is_a: BTO:0001530 ! glioblastoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-10-09T13:21:31Z
 
 [Term]
@@ -50202,7 +50219,7 @@ name: IN-2045 cell
 def: "Human glioblastoma cell line." [PMID:27564115]
 synonym: "IN2045 cell" RELATED []
 is_a: BTO:0001530 ! glioblastoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-10-09T13:22:04Z
 
 [Term]
@@ -50212,7 +50229,7 @@ def: "Human pancreas carcinoma cell line,\nestablished from the malignant ascite
 synonym: "HuP-T3 cell" RELATED []
 synonym: "HUPT3 cell" RELATED []
 is_a: BTO:0000794 ! pancreatic cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-10-09T13:24:30Z
 
 [Term]
@@ -50222,7 +50239,7 @@ def: "Rat Fischer Leydig cell testicular tumour\ncell line, established  from a 
 synonym: "LC 540 cell" RELATED []
 synonym: "LC540 cell" RELATED []
 is_a: BTO:0001560 ! testicular cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-10-09T13:28:41Z
 
 [Term]
@@ -50232,7 +50249,7 @@ def: "Monkey kidney cell line." [ATCC_American_Cell_Type_Culture_Collection:http
 synonym: "MARC 145 cell" RELATED []
 synonym: "MARC145 cell" RELATED []
 is_a: BTO:0000067 ! kidney cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-10-09T13:44:03Z
 
 [Term]
@@ -50240,7 +50257,7 @@ id: BTO:0006550
 name: RBL-5 cell
 def: "Murine leukemia cell line, induced by Rauscher murine leukemia virus (R-MuLV) carried in the ascites form in C57BL/6 mice was cultivated in vitro and passaged continuously." [PMID:864745]
 is_a: BTO:0000737 ! leukemia cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-10-09T20:51:59Z
 
 [Term]
@@ -50250,7 +50267,7 @@ def: "Mouse neural stem cell line." [PMID:20626555]
 synonym: "NS5 cell" RELATED []
 synonym: "NS5 neural stem cell" RELATED []
 is_a: BTO:0002891 ! neural stem cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-10-09T20:56:24Z
 
 [Term]
@@ -50259,17 +50276,16 @@ name: SWH-80 cell
 def: "Human colorectal carcinoma cell line." [PMID:28797028]
 synonym: "SWH80 cell" RELATED []
 is_a: BTO:0001616 ! colorectal cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-10-09T21:09:35Z
 
 [Term]
 id: BTO:0006553
 name: Sa-3 cell
 def: "Human oral squamous cell carcinoma cell line." [PMID:15756446]
-synonym: "<new synonym>" RELATED []
 synonym: "Sa3 cell" RELATED []
 is_a: BTO:0002211 ! oral squamous cell carcinoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-10-09T21:12:33Z
 
 [Term]
@@ -50279,7 +50295,7 @@ def: "Mouse mammary tumor cell line, derived from a primary mammary tumor of a M
 synonym: "Mvt-1 cell" RELATED []
 synonym: "Mvt1 cell" RELATED []
 is_a: BTO:0004086 ! mammary gland tumor cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-10-09T21:19:38Z
 
 [Term]
@@ -50287,7 +50303,7 @@ id: BTO:0006555
 name: SVG-A cell
 def: "Human fetal astrocyte cell line." [Ximbio.com:https\://ximbio.com/search/cell-lines]
 is_a: BTO:0002600 ! astrocyte cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-10-09T21:22:55Z
 
 [Term]
@@ -50296,7 +50312,7 @@ name: U-5A cell
 def: "The human sarcoma cell line HT 1080 was transfected with a vector encoding a selectable marker (guanine phosphoribosyltransferase) regulated by alpha interferon to create the 2fTGH cell line, enabling the selection of mutations in genes encoding components of the interferon signalling pathway. Chemical mutagenesis of the parent 2fTGH cell line enabled the isolation of a number of IFNg signalling mutants available from ECACC: U2A , U3A , U4A, U4C, U5A, U6A. Each contains a different mutation in the IFN signalling pathway. The 2fTGH panel provides a tool for the in vitro study and comparison of disrupted interferon signalling at multiple points across the IFN pathway. The U5A mutant cell line lacks the ifnar2-2 component of the interferon-alpha and interferon-beta receptor and the beta-R1 gene product. U5A is completely defective in interferon alphabeta binding and response." [European_collection_of_cell_cultures:ECACC]
 synonym: "U5A cell" RELATED []
 relationship: develops_from BTO:0005765 ! 2fTGH cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-10-09T21:27:13Z
 
 [Term]
@@ -50307,7 +50323,7 @@ synonym: "SKOv3.ip1 cell" RELATED []
 synonym: "SKOV3ip cell" RELATED []
 synonym: "SKOV3ip1 cell" RELATED []
 relationship: develops_from BTO:0000948 ! SKOV-3 cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-10-10T20:47:54Z
 
 [Term]
@@ -50318,7 +50334,7 @@ synonym: "SCNC cell" RELATED []
 synonym: "small-cell neuroendocrine carcinoma cell" RELATED []
 is_a: BTO:0001407 ! neuroendocrine tumor cell
 is_a: BTO:0002058 ! non-small cell lung cancer cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-10-10T20:55:00Z
 
 [Term]
@@ -50328,7 +50344,7 @@ synonym: "endometrial stromal cell" RELATED []
 synonym: "uterine stromal cell" RELATED []
 is_a: BTO:0002064 ! stromal cell
 relationship: part_of BTO:0001422 ! uterine endometrium
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-10-10T21:10:43Z
 
 [Term]
@@ -50337,7 +50353,7 @@ name: Cor-1 cell
 def: "Neural stem cell line from mouse foetal cortex." [PMID:19798744]
 is_a: BTO:0001242 ! fetal cell line
 is_a: BTO:0002891 ! neural stem cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-10-19T12:57:05Z
 
 [Term]
@@ -50346,7 +50362,7 @@ name: hepatic oval cell
 def: "Hepatic oval cells are a small subpopulation of cells found in the liver when hepatocyte proliferation is inhibited and followed by some type of hepatic injury. These cells are believed to be bipotential, i.e., able to differentiate into hepatocytes or bile ductular cells." [PMID:9462642]
 synonym: "HOC cell" RELATED []
 is_a: BTO:0004270 ! adult liver stem cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-10-19T13:36:20Z
 
 [Term]
@@ -50354,7 +50370,7 @@ id: BTO:0006562
 name: RMA cell
 def: "Mouse T-lymphoma cell line." [PMID:8107849]
 is_a: BTO:0003212 ! T-lymphoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-10-19T14:04:43Z
 
 [Term]
@@ -50362,7 +50378,7 @@ id: BTO:0006563
 name: RMA-S cell
 def: "TAP2 (Antigen peptide transporter 2)-deficient derivative of RMA mouse T-lymphoma cell line." [PMID:8107849]
 relationship: develops_from BTO:0006562 ! RMA cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-10-19T14:06:05Z
 
 [Term]
@@ -50372,7 +50388,7 @@ def: "Human lung small cell lung cancer cell line." [PMID:11030152]
 synonym: "H-1628 cell" RELATED []
 synonym: "H1628 cell" RELATED []
 is_a: BTO:0002206 ! small cell lung cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-10-19T18:16:10Z
 
 [Term]
@@ -50382,7 +50398,7 @@ def: "Human lung small cell lung cancer cell line." [PMID:11030152]
 synonym: "H-3282 cell" RELATED []
 synonym: "H3282 cell" RELATED []
 is_a: BTO:0002206 ! small cell lung cancer cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-10-19T18:19:20Z
 
 [Term]
@@ -50391,7 +50407,7 @@ name: T1 cell
 def: "This line is a cloned hybrid between the 721.174 (variant of the LCL 721 B lymphoblastic cell line) and CEMR.3 (8-azaguanine and ouabain resistant clone of the CEM T lymphoblastic cell line)." [ATCC_American_Cell_Type_Culture_Collection:http\\\://www.lgcstandards-atcc.org/]
 synonym: "174xCEM.T1 cell" RELATED []
 is_a: BTO:0001926 ! hybridoma cell line
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-10-19T18:32:00Z
 
 [Term]
@@ -50400,7 +50416,7 @@ name: neuromuscular system
 def: "The muscles of the body together with the nerves supplying them." [Dictionary.com:https\\\://www.dictionary.com/]
 synonym: "neuro-muscular system" RELATED []
 is_a: BTO:0001485 ! muscular system
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-10-19T19:56:51Z
 
 [Term]
@@ -50414,7 +50430,7 @@ synonym: "Ishikawa-3H-12 cell" RELATED []
 synonym: "Ishikawa-H-12 cell" RELATED []
 synonym: "Ishikawa3-H-12 cell" RELATED []
 relationship: develops_from BTO:0003041 ! Ishikawa cell
-created_by: Marion
+created_by: Marion Gremse
 creation_date: 2021-10-22T15:19:37Z
 
 [Typedef]


### PR DESCRIPTION
This PR standardizes the text for all of the `created_by` tags wrt Marion as well as removes redundant `curator:mgr` annotations from the xrefs in the definitions in a handfull (<20) of occurrences

Ideally, these would be more actionable by using an ORCID id, but I couldn't find one for Marion