### PR TITLE
Add root annotation to BTO

### DIFF
--- a/src/ontology/bto-edit.obo
+++ b/src/ontology/bto-edit.obo
@@ -11,6 +11,7 @@ ontology: bto
 property_value: http://purl.org/dc/elements/1.1/description "A structured controlled vocabulary for the source of an enzyme comprising tissues, cell lines, cell types and cell cultures." xsd:string
 property_value: http://purl.org/dc/elements/1.1/title "The BRENDA Tissue Ontology (BTO)" xsd:string
 property_value: http://purl.org/dc/terms/license https://creativecommons.org/licenses/by/4.0/ xsd:string
+property_value: IAO:0000700 BTO:0000000
 
 [Term]
 id: BTO:0000000


### PR DESCRIPTION
Related to https://github.com/OBOFoundry/OBOFoundry.github.io/issues/2149

## What This PR Does

Applies the annotation property [has ontology root term (IAO:0000700)](http://purl.obolibrary.org/obo/IAO_0000700) at the the ontology level to list the following terms from this ontology as "root terms":

1. BTO:000000

## Why this is helpful

- the Ontology Lookup Service uses this to help better display ontologies
- if any of the terms mentioned above are ever aligned with an upper ontology like BFO, it still will be the thing shown on OLS as the "root"
- this will be generally useful for things like alignment with COB since it makes it easier to figure out what are the upper level terms in this ontology are

CC @chdudek @BRENDA-Enzymes 